### PR TITLE
Arty: Allow a slower core clk

### DIFF
--- a/src/main/scala/ip/xilinx/Xilinx.scala
+++ b/src/main/scala/ip/xilinx/Xilinx.scala
@@ -117,6 +117,7 @@ class mmcm extends BlackBox {
     val clk_out1 = Output(Clock())
     val clk_out2 = Output(Clock())
     val clk_out3 = Output(Clock())
+    val clk_out4 = Output(Clock())
     val resetn   = Input(Bool())
     val locked   = Output(Bool())
   }

--- a/src/main/scala/shell/xilinx/ArtyShell.scala
+++ b/src/main/scala/shell/xilinx/ArtyShell.scala
@@ -103,7 +103,8 @@ abstract class ArtyShell(implicit val p: Parameters) extends RawModule {
 
   // Note: these frequencies are approximate.
   val clock_8MHz     = Wire(Clock())
-  val clock_32MHz    = Wire(Clock())
+  val clock_16MHz25    = Wire(Clock())
+  val clock_32MHz5    = Wire(Clock())
   val clock_65MHz    = Wire(Clock())
 
   val mmcm_locked    = Wire(Bool())
@@ -132,8 +133,9 @@ abstract class ArtyShell(implicit val p: Parameters) extends RawModule {
 
   ip_mmcm.io.clk_in1 := CLK100MHZ
   clock_8MHz         := ip_mmcm.io.clk_out1  // 8.388 MHz = 32.768 kHz * 256
-  clock_65MHz        := ip_mmcm.io.clk_out2  // 65 Mhz
-  clock_32MHz        := ip_mmcm.io.clk_out3  // 65/2 Mhz
+  clock_65MHz        := ip_mmcm.io.clk_out2  // 65 MHz
+  clock_32MHz5       := ip_mmcm.io.clk_out3  // 65/2 MHz
+  clock_16MHz25      := ip_mmcm.io.clk_out4  // 65/2/2 MHz
   ip_mmcm.io.resetn  := ck_rst
   mmcm_locked        := ip_mmcm.io.locked
 
@@ -192,7 +194,7 @@ abstract class ArtyShell(implicit val p: Parameters) extends RawModule {
     // JTAG Reset
     //-------------------------------------------------------------------
 
-    val jtag_power_on_reset = PowerOnResetFPGAOnly(clock_32MHz)
+    val jtag_power_on_reset = PowerOnResetFPGAOnly(clock_32MHz5)
 
     dut_jtag_reset := jtag_power_on_reset
 

--- a/xilinx/arty/constraints/arty-master.xdc
+++ b/xilinx/arty/constraints/arty-master.xdc
@@ -237,4 +237,5 @@ set_clock_groups -asynchronous \
      [get_clocks -of_objects [get_pins ip_mmcm/inst/mmcm_adv_inst/CLKOUT0]]] \
   -group [list \
      [get_clocks -of_objects [get_pins ip_mmcm/inst/mmcm_adv_inst/CLKOUT1]] \
-     [get_clocks -of_objects [get_pins ip_mmcm/inst/mmcm_adv_inst/CLKOUT2]]]
+     [get_clocks -of_objects [get_pins ip_mmcm/inst/mmcm_adv_inst/CLKOUT2]] \
+     [get_clocks -of_objects [get_pins ip_mmcm/inst/mmcm_adv_inst/CLKOUT3]]]

--- a/xilinx/arty/tcl/ip.tcl
+++ b/xilinx/arty/tcl/ip.tcl
@@ -7,10 +7,12 @@ set_property -dict [list \
 	CONFIG.CLKOUT1_USED {true} \
         CONFIG.CLKOUT2_USED {true} \
         CONFIG.CLKOUT3_USED {true} \
-	CONFIG.CLKOUT1_REQUESTED_OUT_FREQ {8.388} \
-        CONFIG.CLKOUT2_REQUESTED_OUT_FREQ {65.000} \
-        CONFIG.CLKOUT3_REQUESTED_OUT_FREQ {32.500} \
-	] [get_ips mmcm]
+        CONFIG.CLKOUT4_USED {true} \
+        CONFIG.CLKOUT1_REQUESTED_OUT_FREQ {8.388}   \
+        CONFIG.CLKOUT2_REQUESTED_OUT_FREQ {65.000}  \
+        CONFIG.CLKOUT3_REQUESTED_OUT_FREQ {32.500}  \
+        CONFIG.CLKOUT4_REQUESTED_OUT_FREQ {16.2500} \
+       	] [get_ips mmcm]
 
 create_ip -vendor xilinx.com -library ip -name proc_sys_reset -module_name reset_sys -dir $ipdir -force
 set_property -dict [list \


### PR DESCRIPTION
Add a further divided clock for use if designs can't meet 65MHz timing.  Also rename the clock frequencies to be more precise.