### PR TITLE
signal_bundles: Use the new way as .fromPorts is gone

### DIFF
--- a/src/main/scala/shell/xilinx/ArtyShell.scala
+++ b/src/main/scala/shell/xilinx/ArtyShell.scala
@@ -166,7 +166,7 @@ abstract class ArtyShell(implicit val p: Parameters) extends RawModule {
       val qspi_params = qspiParams(0)
       val qspi_pins = Wire(new SPIPins(() => {new BasePin()}, qspi_params))
 
-      qspi_pins.fromPort(
+      SPIPinsFromPort(qspi_pins,
         dut.qspi(0),
         dut.clock,
         dut.reset,


### PR DESCRIPTION
This goes along with https://github.com/sifive/sifive-blocks/pull/39