### PR TITLE
Restructure Tcl script entrypoint.

### DIFF
--- a/xilinx/common/tcl/init.tcl
+++ b/xilinx/common/tcl/init.tcl
@@ -10,8 +10,8 @@ file mkdir $ipdir
 update_ip_catalog -rebuild
 
 # Generate IP implementations. Vivado TCL emitted from Chisel Blackboxes
-foreach ipvivadotcl $ipvivadotcls {
-  source $ipvivadotcl
+foreach ip_vivado_tcl $ip_vivado_tcls {
+  source $ip_vivado_tcl
 }
 # Optional board-specific ip script
 set boardiptcl [file join $boarddir tcl ip.tcl]

--- a/xilinx/common/tcl/vivado.tcl
+++ b/xilinx/common/tcl/vivado.tcl
@@ -1,11 +1,20 @@
 # See LICENSE for license details.
 
+# Set the variable for the directory that includes all scripts
+set scriptdir [file dirname [info script]]
+
+# Set up variables and Vivado objects
+source [file join $scriptdir "prologue.tcl"]
+
+# Initialize Vivado project files
+source [file join $scriptdir "init.tcl"]
+
 # Synthesize the design
 source [file join $scriptdir "synth.tcl"]
 
 # Pre-implementation debug
-if {[info exists ::env(PRE_IMPL_DEBUG_TCL)]} {
-  source [file join $scriptdir $::env(PRE_IMPL_DEBUG_TCL)]
+if {[info exists pre_impl_debug_tcl]} {
+  source [file join $scriptdir $pre_impl_debug_tcl]
 }
 
 # Post synthesis optimization
@@ -21,8 +30,8 @@ source [file join $scriptdir "route.tcl"]
 source [file join $scriptdir "bitstream.tcl"]
 
 # Post-implementation debug
-if {[info exists ::env(POST_IMPL_DEBUG_TCL)]} {
-  source [file join $scriptdir $::env(POST_IMPL_DEBUG_TCL)]
+if {[info exists post_impl_debug_tcl)]} {
+  source [file join $scriptdir $post_impl_debug_tcl]
 }
 
 # Create reports for the current implementation


### PR DESCRIPTION
I've made a few changes that make it easier to run the Vivado Tcl scripts in a larger project. Main changes made:

## Only one entrypoint script
Previously we had to pass several different scripts in the correct order to Vivado. In this PR vivado.tcl is now the entrypoint for all the Vivado Tcl scripts and will automatically source all the other required scripts. It will even source the correct `board` script via the `-board` command line argument.

## Command line arguments
A command line argument parser was written and replaces the previous system of using environment variables to pass values into the scripts. This makes it clearer where options come from and makes it harder to accidentally mix up environment variables when working on different projects.

## Providing vsrcs as flat file
The `VSRCSVIVADOTCL` environment variable has been replaced with a `-F` command line option, and the file format has changed from a Tcl script to a simple newline-delimited list of files. This makes it similar to the `-F` flag for other EDA tools, which is used to provide additional command line arguments from a file, in that if we *only* put files and not command line options in the file, it is compatible with other tools.

## How this was tested
I ran our FPGA regression tests on this branch, and everything still passes.