### PR TITLE
Allow additional constraints directory to be provided

### DIFF
--- a/xilinx/common/tcl/prologue.tcl
+++ b/xilinx/common/tcl/prologue.tcl
@@ -20,6 +20,9 @@ while {[llength $argv]} {
     -ip-vivado-tcls {
       set argv [lassign $argv[set argv {}] ip_vivado_tcls]
     }
+    -addl_constraint_dir {
+      set argv [lassign $argv[set argv {}] addl_constrant_dir]
+    }
     -pre-impl-debug-tcl {
       set argv [lassign $argv[set argv {}] pre_impl_debug_tcl]
     }
@@ -116,3 +119,7 @@ if {[get_filesets -quiet constrs_1] eq ""} {
 
 set obj [current_fileset -constrset]
 add_files -norecurse -fileset $obj [glob -directory $constraintsdir {*.xdc}]
+
+if {[info exists addl_constraint_dir]} {
+    add_files -norecurse -fileset $obj [glob -directory $addl_constraint_dir {*.xdc}]
+}

--- a/xilinx/common/tcl/prologue.tcl
+++ b/xilinx/common/tcl/prologue.tcl
@@ -20,8 +20,8 @@ while {[llength $argv]} {
     -ip-vivado-tcls {
       set argv [lassign $argv[set argv {}] ip_vivado_tcls]
     }
-    -addl_constraint_dir {
-      set argv [lassign $argv[set argv {}] addl_constrant_dir]
+    -addl-constraint-dir {
+      set argv [lassign $argv[set argv {}] addl_constraint_dir]
     }
     -pre-impl-debug-tcl {
       set argv [lassign $argv[set argv {}] pre_impl_debug_tcl]
@@ -121,5 +121,6 @@ set obj [current_fileset -constrset]
 add_files -norecurse -fileset $obj [glob -directory $constraintsdir {*.xdc}]
 
 if {[info exists addl_constraint_dir]} {
+    set obj [current_fileset -constrset]
     add_files -norecurse -fileset $obj [glob -directory $addl_constraint_dir {*.xdc}]
 }

--- a/xilinx/common/tcl/prologue.tcl
+++ b/xilinx/common/tcl/prologue.tcl
@@ -55,7 +55,7 @@ set boarddir [file join [file dirname $commondir] $board]
 source [file join $boarddir tcl board.tcl]
 
 # Set the variable that points to board constraint files
-set constraintsdir [file join $boarddir constraints]
+set constraintsdirs [list [file join $boarddir constraints]]
 
 # Set the variable that points to common verilog sources
 set srcdir [file join $commondir vsrc]
@@ -117,10 +117,11 @@ if {[get_filesets -quiet constrs_1] eq ""} {
 	create_fileset -constrset constrs_1
 }
 
-set obj [current_fileset -constrset]
-add_files -norecurse -fileset $obj [glob -directory $constraintsdir {*.xdc}]
-
 if {[info exists addl_constraint_dir]} {
-    set obj [current_fileset -constrset]
-    add_files -norecurse -fileset $obj [glob -directory $addl_constraint_dir {*.xdc}]
+    set constraintsdirs [concat $constraintsdirs $addl_constraint_dir]
+}
+
+foreach constraintsdir $constraintsdirs {
+  set obj [current_fileset -constrset]
+  add_files -norecurse -fileset $obj [glob -directory $constraintsdir {*.xdc}]
 }


### PR DESCRIPTION
In general we probably want to allow additional hooks to be inserted. For starters, allow user to specify additional design constraints in the form of additional constraint directories