### PR TITLE
VC707 use IP IO bundles

### DIFF
--- a/src/main/scala/devices/xilinx/xilinxvc707pciex1/XilinxVC707PCIeX1.scala
+++ b/src/main/scala/devices/xilinx/xilinxvc707pciex1/XilinxVC707PCIeX1.scala
@@ -10,14 +10,20 @@ import freechips.rocketchip.tilelink._
 import sifive.fpgashells.ip.xilinx.vc707axi_to_pcie_x1.{VC707AXIToPCIeX1, VC707AXIToPCIeX1IOClocksReset, VC707AXIToPCIeX1IOSerial}
 import sifive.fpgashells.ip.xilinx.ibufds_gte2.IBUFDS_GTE2
 
-class XilinxVC707PCIeX1Pads extends Bundle with VC707AXIToPCIeX1IOSerial
+trait VC707AXIToPCIeRefClk extends Bundle{
+  val REFCLK_rxp = Bool(INPUT)
+  val REFCLK_rxn = Bool(INPUT)
+}
+
+class XilinxVC707PCIeX1Pads extends Bundle 
+  with VC707AXIToPCIeX1IOSerial
+  with VC707AXIToPCIeRefClk
 
 class XilinxVC707PCIeX1IO extends Bundle
+    with VC707AXIToPCIeRefClk
     with VC707AXIToPCIeX1IOSerial
     with VC707AXIToPCIeX1IOClocksReset {
   val axi_ctl_aresetn = Bool(INPUT)
-  val REFCLK_rxp = Bool(INPUT)
-  val REFCLK_rxn = Bool(INPUT)
 }
 
 class XilinxVC707PCIeX1(implicit p: Parameters) extends LazyModule {

--- a/src/main/scala/shell/xilinx/VC707Shell.scala
+++ b/src/main/scala/shell/xilinx/VC707Shell.scala
@@ -35,21 +35,7 @@ abstract class VC707Shell(implicit val p: Parameters) extends RawModule {
   val reset                = IO(Input(Bool()))
 
   // DDR SDRAM
-  val ddr3_addr            = IO(Output(UInt(16.W)))
-  val ddr3_ba              = IO(Output(UInt(3.W)))
-  val ddr3_cas_n           = IO(Output(Bool()))
-  val ddr3_ck_p            = IO(Output(Bool()))
-  val ddr3_ck_n            = IO(Output(Bool()))
-  val ddr3_cke             = IO(Output(Bool()))
-  val ddr3_cs_n            = IO(Output(Bool()))
-  val ddr3_dm              = IO(Output(UInt(8.W)))
-  val ddr3_dq              = IO(Analog(64.W))
-  val ddr3_dqs_n           = IO(Analog(8.W))
-  val ddr3_dqs_p           = IO(Analog(8.W))
-  val ddr3_odt             = IO(Output(Bool()))
-  val ddr3_ras_n           = IO(Output(Bool()))
-  val ddr3_reset_n         = IO(Output(Bool()))
-  val ddr3_we_n            = IO(Output(Bool()))
+  val ddr                  = IO(new XilinxVC707MIGPads(p(MemoryXilinxDDRKey)))
 
   // LED
   val led                  = IO(Vec(8, Output(Bool())))
@@ -72,12 +58,7 @@ abstract class VC707Shell(implicit val p: Parameters) extends RawModule {
   val jtag_TDO             = IO(Output(Bool()))
 
   // PCIe
-  val pci_exp_txp          = IO(Output(Bool()))
-  val pci_exp_txn          = IO(Output(Bool()))
-  val pci_exp_rxp          = IO(Input(Bool()))
-  val pci_exp_rxn          = IO(Input(Bool()))
-  val pci_exp_refclk_rxp   = IO(Input(Bool()))
-  val pci_exp_refclk_rxn   = IO(Input(Bool()))
+  val pcie                 = IO(new XilinxVC707PCIeX1Pads)
 
   //-----------------------------------------------------------------------
   // Wire declrations
@@ -257,23 +238,7 @@ abstract class VC707Shell(implicit val p: Parameters) extends RawModule {
     dut.xilinxvc707mig.aresetn   := mig_resetn
     dut.xilinxvc707mig.sys_rst   := sys_reset
 
-    // Outputs
-    ddr3_addr    := dut.xilinxvc707mig.ddr3_addr
-    ddr3_ba      := dut.xilinxvc707mig.ddr3_ba
-    ddr3_ras_n   := dut.xilinxvc707mig.ddr3_ras_n
-    ddr3_cas_n   := dut.xilinxvc707mig.ddr3_cas_n
-    ddr3_we_n    := dut.xilinxvc707mig.ddr3_we_n
-    ddr3_reset_n := dut.xilinxvc707mig.ddr3_reset_n
-    ddr3_ck_p    := dut.xilinxvc707mig.ddr3_ck_p
-    ddr3_ck_n    := dut.xilinxvc707mig.ddr3_ck_n
-    ddr3_cke     := dut.xilinxvc707mig.ddr3_cke
-    ddr3_cs_n    := dut.xilinxvc707mig.ddr3_cs_n
-    ddr3_dm      := dut.xilinxvc707mig.ddr3_dm
-    ddr3_odt     := dut.xilinxvc707mig.ddr3_odt
-
-    attach(ddr3_dq,    dut.xilinxvc707mig.ddr3_dq)
-    attach(ddr3_dqs_n, dut.xilinxvc707mig.ddr3_dqs_n)
-    attach(ddr3_dqs_p, dut.xilinxvc707mig.ddr3_dqs_p)
+    ddr <> dut.xilinxvc707mig
   }
 
   //---------------------------------------------------------------------
@@ -287,14 +252,8 @@ abstract class VC707Shell(implicit val p: Parameters) extends RawModule {
     pcie_cfg_clock                      := dut.xilinxvc707pcie.axi_ctl_aclk_out
     mmcm_lock_pcie                      := dut.xilinxvc707pcie.mmcm_lock
     dut.xilinxvc707pcie.axi_ctl_aresetn := pcie_dat_resetn
-    dut.xilinxvc707pcie.REFCLK_rxp      := pci_exp_refclk_rxp
-    dut.xilinxvc707pcie.REFCLK_rxn      := pci_exp_refclk_rxn
 
-    // PCIeX1 connections
-    pci_exp_txp                         := dut.xilinxvc707pcie.pci_exp_txp
-    pci_exp_txn                         := dut.xilinxvc707pcie.pci_exp_txn
-    dut.xilinxvc707pcie.pci_exp_rxp     := pci_exp_rxp
-    dut.xilinxvc707pcie.pci_exp_rxn     := pci_exp_rxn
+    pcie <> dut.xilinxvc707pcie
   }
 
 }

--- a/xilinx/vc707/constraints/vc707-master.xdc
+++ b/xilinx/vc707/constraints/vc707-master.xdc
@@ -35,16 +35,16 @@ set_property IOB TRUE [get_cells "uart_rxd_sync/sync_1"]
 
 # PCI Express
 #FMC 1 refclk
-set_property PACKAGE_PIN A10 [get_ports {pci_exp_refclk_rxp}]
-set_property PACKAGE_PIN A9 [get_ports {pci_exp_refclk_rxn}]
-create_clock -name pcie_ref_clk -period 10 [get_ports pci_exp_refclk_rxp]
-set_input_jitter [get_clocks -of_objects [get_ports pci_exp_refclk_rxp]] 0.5
+set_property PACKAGE_PIN A10 [get_ports {pcie_REFCLK_rxp}]
+set_property PACKAGE_PIN A9 [get_ports {pcie_REFCLK_rxn}]
+create_clock -name pcie_ref_clk -period 10 [get_ports pcie_REFCLK_rxp]
+set_input_jitter [get_clocks -of_objects [get_ports pcie_REFCLK_rxp]] 0.5
 
-set_property PACKAGE_PIN H4 [get_ports {pci_exp_txp}]
-set_property PACKAGE_PIN H3 [get_ports {pci_exp_txn}]
+set_property PACKAGE_PIN H4 [get_ports {pcie_pci_exp_txp}]
+set_property PACKAGE_PIN H3 [get_ports {pcie_pci_exp_txn}]
 
-set_property PACKAGE_PIN G6 [get_ports {pci_exp_rxp}]
-set_property PACKAGE_PIN G5 [get_ports {pci_exp_rxn}]
+set_property PACKAGE_PIN G6 [get_ports {pcie_pci_exp_rxp}]
+set_property PACKAGE_PIN G5 [get_ports {pcie_pci_exp_rxn}]
 
 # JTAG
 set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets jtag_TCK_IBUF]


### PR DESCRIPTION
For Shell IO, use the bundles directly from PCIe and MIG IPs instead of flattening and renaming