### PR TITLE
TransferSizes: just because a device CAN do more does not mean it should

### DIFF
--- a/src/main/scala/devices/xilinx/xilinxvc707mig/XilinxVC707MIG.scala
+++ b/src/main/scala/devices/xilinx/xilinxvc707mig/XilinxVC707MIG.scala
@@ -38,8 +38,8 @@ class XilinxVC707MIGIsland(c : XilinxVC707MIGParams)(implicit p: Parameters) ext
       resources     = device.reg,
       regionType    = RegionType.UNCACHED,
       executable    = true,
-      supportsWrite = TransferSizes(1, 256*8),
-      supportsRead  = TransferSizes(1, 256*8))),
+      supportsWrite = TransferSizes(1, 128),
+      supportsRead  = TransferSizes(1, 128))),
     beatBytes = 8)))
 
   lazy val module = new LazyModuleImp(this) {

--- a/src/main/scala/ip/xilinx/vc707axi_to_pcie_x1/vc707axi_to_pcie_x1.scala
+++ b/src/main/scala/ip/xilinx/vc707axi_to_pcie_x1/vc707axi_to_pcie_x1.scala
@@ -196,8 +196,8 @@ class VC707AXIToPCIeX1(implicit p:Parameters) extends LazyModule
       address       = List(AddressSet(0x60000000L, 0x1fffffffL)),
       resources     = Seq(Resource(device, "ranges")),
       executable    = true,
-      supportsWrite = TransferSizes(1, 256),
-      supportsRead  = TransferSizes(1, 256))),
+      supportsWrite = TransferSizes(1, 128),
+      supportsRead  = TransferSizes(1, 128))),
     beatBytes = 8)))
 
   val control = AXI4SlaveNode(Seq(AXI4SlavePortParameters(


### PR DESCRIPTION
Capping TransferSizes at 128 fits nicely in 3 size bits.