### PR TITLE
Dynamic clock groups

### DIFF
--- a/xilinx/common/tcl/prologue.tcl
+++ b/xilinx/common/tcl/prologue.tcl
@@ -115,4 +115,5 @@ if {[get_filesets -quiet constrs_1] eq ""} {
 }
 
 set obj [current_fileset -constrset]
-add_files -norecurse -fileset $obj [glob -directory $constraintsdir {*.xdc}]
+add_files -norecurse -fileset $obj [glob -directory $constraintsdir -nocomplain {*.xdc}]
+add_files -norecurse -fileset $obj [glob -directory $constraintsdir -nocomplain {*.tcl}]

--- a/xilinx/vc707/constraints/vc707-master.tcl
+++ b/xilinx/vc707/constraints/vc707-master.tcl
@@ -1,0 +1,25 @@
+if { [llength [get_ports -quiet chiplink_b2c_clk]] > 0 } {
+  create_clock -name chiplink_b2c_clock -period 10 [get_ports chiplink_b2c_clk]
+}
+
+set group_mem [get_clocks -quiet {clk_pll_i}]
+set group_sys [get_clocks -quiet {sys_diff_clk                    \
+                                  clk_out*_vc707_sys_clock_mmcm1  \
+                                  clk_out*_vc707_sys_clock_mmcm2}]
+set group_cl  [get_clocks -quiet {chiplink_b2c_clock              \
+                                  clk_out*_vc707_sys_clock_mmcm3}]
+set group_pci [get_clocks -quiet -include_generated_clocks -of_objects [get_pins -hier -filter {name =~ *pcie*TXOUTCLK}]]
+
+puts "group_mem: $group_mem"
+puts "group_sys: $group_sys"
+puts "group_pci: $group_pci"
+puts "group_cl:  $group_cl"
+
+set groups [list]
+if { [llength $group_mem] > 0 } { lappend groups -group $group_mem }
+if { [llength $group_sys] > 0 } { lappend groups -group $group_sys }
+if { [llength $group_pci] > 0 } { lappend groups -group $group_pci }
+if { [llength $group_cl]  > 0 } { lappend groups -group $group_cl }
+
+puts "set_clock_groups -asynchronous $groups"
+set_clock_groups -asynchronous {*}$groups

--- a/xilinx/vc707/constraints/vc707-master.xdc
+++ b/xilinx/vc707/constraints/vc707-master.xdc
@@ -71,24 +71,3 @@ set_property -dict { PACKAGE_PIN AR30  IOSTANDARD LVCMOS18  IOB TRUE  PULLUP TRU
 set_property -dict { PACKAGE_PIN AU31  IOSTANDARD LVCMOS18  IOB TRUE  PULLUP TRUE } [get_ports {sdio_dat[1]}]
 set_property -dict { PACKAGE_PIN AV31  IOSTANDARD LVCMOS18  IOB TRUE  PULLUP TRUE } [get_ports {sdio_dat[2]}]
 set_property -dict { PACKAGE_PIN AT30  IOSTANDARD LVCMOS18  IOB TRUE  PULLUP TRUE } [get_ports {sdio_dat[3]}]
-
-create_clock -name chiplink_b2c_clock -period 10 [get_ports chiplink_b2c_clk]
-
-set_clock_groups -asynchronous \
-  -group { clk_pll_i } \
-  -group { \
-	sys_diff_clk \
-	clk_out1_vc707_sys_clock_mmcm2 \
-	clk_out2_vc707_sys_clock_mmcm2 \
-	clk_out3_vc707_sys_clock_mmcm2 \
-	clk_out4_vc707_sys_clock_mmcm2 \
-	clk_out5_vc707_sys_clock_mmcm2 \
-	clk_out6_vc707_sys_clock_mmcm2 \
-	clk_out7_vc707_sys_clock_mmcm2 } \
-  -group { \
-	clk_out1_vc707_sys_clock_mmcm1 \
-	clk_out2_vc707_sys_clock_mmcm1 } \
-  -group { \
-        clk_out1_vc707_sys_clock_mmcm3 \
-        chiplink_b2c_clock } \
-  -group [list [get_clocks -include_generated_clocks -of_objects [get_pins -hier -filter {name =~ *pcie*TXOUTCLK}]]]


### PR DESCRIPTION
This is needed because sometimes PCIe/DDR/CL/etc are disabled. In those cases we still need to cut the remaining clock groups.