### PR TITLE
VC707PCIe: adapt to AXI4Lite API change

### DIFF
--- a/src/main/scala/devices/xilinx/xilinxvc707pciex1/XilinxVC707PCIeX1.scala
+++ b/src/main/scala/devices/xilinx/xilinxvc707pciex1/XilinxVC707PCIeX1.scala
@@ -44,7 +44,7 @@ class XilinxVC707PCIeX1(implicit p: Parameters) extends LazyModule with HasCross
       := AXI4Buffer()
       := AXI4UserYanker(capMaxFlight = Some(2))
       := TLToAXI4()
-      := TLFragmenter(4, p(CacheBlockBytes)))
+      := TLFragmenter(4, p(CacheBlockBytes), holdFirstDeny = true))
 
   val master: TLOutwardNode =
     (TLWidthWidget(8)


### PR DESCRIPTION
Changing AXI4 to support denied requires AXI4Lite adapters to change TLFragmenter options.