### PR TITLE
Make 2.12 type checker happy

### DIFF
--- a/src/main/scala/ip/microsemi/polarfire_pcie_rootport/PolarFirePCIeRootPort.scala
+++ b/src/main/scala/ip/microsemi/polarfire_pcie_rootport/PolarFirePCIeRootPort.scala
@@ -177,8 +177,10 @@ class PolarFirePCIeX4(implicit p:Parameters) extends LazyModule
         "device_type"        -> Seq(ResourceString("pci")),
         "interrupt-map-mask" -> Seq(0, 0, 0, 7).flatMap(ofInt),
         "interrupt-map"      -> Seq(1, 2, 3, 4).flatMap(ofMap),
-        "ranges"             -> resources("ranges").map { case Binding(_, ResourceAddress(address, perms)) =>
-                                                               ResourceMapping(address, BigInt(0x02000000) << 64, perms) },
+        "ranges"             -> resources("ranges").map(x =>
+                                  (x: @unchecked) match { case Binding(_, ResourceAddress(address, perms)) =>
+                                                               ResourceMapping(address,
+                                                                 BigInt(0x02000000) << 64, perms) }),
         "interrupt-controller" -> Seq(ResourceMap(labels = Seq(intc), value = Map(
           "interrupt-controller" -> Nil,
           "#address-cells"       -> ofInt(0),

--- a/src/main/scala/ip/xilinx/vc707axi_to_pcie_x1/vc707axi_to_pcie_x1.scala
+++ b/src/main/scala/ip/xilinx/vc707axi_to_pcie_x1/vc707axi_to_pcie_x1.scala
@@ -181,8 +181,9 @@ class VC707AXIToPCIeX1(implicit p:Parameters) extends LazyModule
         "device_type"        -> Seq(ResourceString("pci")),
         "interrupt-map-mask" -> Seq(0, 0, 0, 7).flatMap(ofInt),
         "interrupt-map"      -> Seq(1, 2, 3, 4).flatMap(ofMap),
-        "ranges"             -> resources("ranges").map { case Binding(_, ResourceAddress(address, perms)) =>
-                                                               ResourceMapping(address, BigInt(0x02000000) << 64, perms) },
+        "ranges"             -> resources("ranges").map(x =>
+                                  (x: @unchecked) match { case Binding(_, ResourceAddress(address, perms)) =>
+                                                               ResourceMapping(address, BigInt(0x02000000) << 64, perms) }),
         "interrupt-controller" -> Seq(ResourceMap(labels = Seq(intc), value = Map(
           "interrupt-controller" -> Nil,
           "#address-cells"       -> ofInt(0),


### PR DESCRIPTION
Scala 2.12's type checker is more thorough than 2.11's. This PR suppresses "match may not be exhaustive" warnings.