### PR TITLE
VC707: fix legacy Shell

### DIFF
--- a/src/main/scala/shell/xilinx/VC707Shell.scala
+++ b/src/main/scala/shell/xilinx/VC707Shell.scala
@@ -604,7 +604,8 @@ abstract class VC707Shell(implicit val p: Parameters) extends RawModule {
   }
 
   ElaborationArtefacts.add("old-shell.vivado.tcl",
-    """source [file join $boarddir tcl clocks.tcl]
-      |source [file join $boarddir tcl ios.tcl]
+    """set obj [current_fileset -constrset]
+      |add_files -quiet -norecurse -fileset $obj [file join $boarddir tcl ios.tcl]
+      |add_files -quiet -norecurse -fileset $obj [file join $boarddir tcl clocks.tcl]
       |""".stripMargin)
 }

--- a/xilinx/vc707/tcl/clocks.tcl
+++ b/xilinx/vc707/tcl/clocks.tcl
@@ -29,7 +29,7 @@ set group_sys [get_clocks -quiet {sys_diff_clk                    \
                                   chiplink_c2b_clock}]
 set group_cl  [get_clocks -quiet {chiplink_b2c_clock              \
                                   clk_out*_vc707_sys_clock_mmcm3}]
-set group_pci [get_clocks -quiet -include_generated_clocks -of_objects [get_pins -hier -filter {name =~ *pcie*TXOUTCLK}]]
+set group_pci [get_clocks -quiet {userclk1 txoutclk}]
 
 set group_jtag [get_clocks -quiet {JTCK}]
 

--- a/xilinx/vc707/tcl/ios.tcl
+++ b/xilinx/vc707/tcl/ios.tcl
@@ -23,7 +23,6 @@ set_property BOARD_PIN {push_buttons_5bits_tri_i_0}  [get_ports btn_0]
 set_property BOARD_PIN {push_buttons_5bits_tri_i_1}  [get_ports btn_1]
 set_property BOARD_PIN {push_buttons_5bits_tri_i_2}  [get_ports btn_2]
 set_property BOARD_PIN {push_buttons_5bits_tri_i_3}  [get_ports btn_3]
-set_property BOARD_PIN {push_buttons_5bits_tri_i_4}  [get_ports btn_5]
 
 set_property BOARD_PIN {dip_switches_tri_i_0} [get_ports sw_0]
 set_property BOARD_PIN {dip_switches_tri_i_1} [get_ports sw_1]
@@ -36,20 +35,16 @@ set_property BOARD_PIN {dip_switches_tri_i_7} [get_ports sw_7]
 
 set_property PACKAGE_PIN AU33 [get_ports uart_rx]
 set_property IOSTANDARD LVCMOS18 [get_ports uart_rx]
-set_property IOB TRUE [get_ports uart_rx]
+set_property IOB TRUE [get_cells -of_objects [all_fanout -flat -endpoints_only [get_ports uart_rx]]]
 set_property PACKAGE_PIN AT32 [get_ports uart_ctsn]
 set_property IOSTANDARD LVCMOS18 [get_ports uart_ctsn]
 set_property IOB TRUE [get_ports uart_ctsn]
 set_property PACKAGE_PIN AU36 [get_ports uart_tx]
 set_property IOSTANDARD LVCMOS18 [get_ports uart_tx]
-set_property IOB TRUE [get_ports uart_tx]
+set_property IOB TRUE  [get_cells -of_objects [all_fanin -flat -startpoints_only [get_ports uart_tx]]]
 set_property PACKAGE_PIN AR34 [get_ports uart_rtsn]
 set_property IOSTANDARD LVCMOS18 [get_ports uart_rtsn]
 set_property IOB TRUE [get_ports uart_rtsn]
-
-# Platform specific constraints
-set_property IOB TRUE [get_cells "U500VC707System/uarts_0/txm/out_reg"]
-set_property IOB TRUE [get_cells "uart_rxd_sync/sync_1"]
 
 # PCI Express
 #FMC 1 refclk


### PR DESCRIPTION
The TCL hooks were in the wrong place.