### PR TITLE
BundleBridge: use source and sink nodes directly

### DIFF
--- a/src/main/scala/shell/LEDOverlay.scala
+++ b/src/main/scala/shell/LEDOverlay.scala
@@ -18,6 +18,6 @@ abstract class LEDOverlay(
   def ioFactory = Output(UInt(width.W))
 
   val ledSource = BundleBridgeSource(() => UInt(width.W))
-  val ledSink = shell { ledSource.sink }
+  val ledSink = shell { ledSource.makeSink() }
   val designOutput = InModuleBody { ledSource.out(0)._1 }
 }

--- a/src/main/scala/shell/SwitchOverlay.scala
+++ b/src/main/scala/shell/SwitchOverlay.scala
@@ -18,6 +18,6 @@ abstract class SwitchOverlay(
   def ioFactory = Input(UInt(width.W))
 
   val switchSource = shell { BundleBridgeSource(() => UInt(width.W)) }
-  val switchSink = switchSource.sink
-  val designOutput = InModuleBody { switchSink.io }
+  val switchSink = switchSource.makeSink()
+  val designOutput = InModuleBody { switchSink.bundle }
 }

--- a/src/main/scala/shell/microsemi/PolarFireEvalKitShell.scala
+++ b/src/main/scala/shell/microsemi/PolarFireEvalKitShell.scala
@@ -372,7 +372,7 @@ trait HasPFEvalKitChipLink { this: PolarFireEvalKitShell =>
 */
   }
 
-  def connectChipLink(dut: { val chiplink: HeterogeneousBag[WideDataLayerPort] } , iofpga: Boolean = false): Unit = {
+  def connectChipLink(dut: { val chiplink: Seq[WideDataLayerPort] } , iofpga: Boolean = false): Unit = {
     constrainChipLink(iofpga)
 
     chiplink <> dut.chiplink(0)

--- a/src/main/scala/shell/microsemi/VeraShell.scala
+++ b/src/main/scala/shell/microsemi/VeraShell.scala
@@ -111,7 +111,7 @@ trait HasPFEvalKitChipLink { this: VeraShell =>
     val direction1Pins = if(iofpga) "chiplink_c2b"  else "chiplink_b2c"
   }
 
-  def connectChipLink(dut: { val chiplink: HeterogeneousBag[WideDataLayerPort] } , iofpga: Boolean = false): Unit = {
+  def connectChipLink(dut: { val chiplink: Seq[WideDataLayerPort] } , iofpga: Boolean = false): Unit = {
     constrainChipLink(iofpga)
 
     chiplink <> dut.chiplink(0)

--- a/src/main/scala/shell/xilinx/LEDOverlay.scala
+++ b/src/main/scala/shell/xilinx/LEDOverlay.scala
@@ -13,7 +13,7 @@ abstract class LEDXilinxOverlay(params: LEDOverlayParams, boardPins: Seq[String]
   val width = boardPins.size + packagePins.size
 
   shell { InModuleBody {
-    io := ledSink.io // could/should put OBUFs here?
+    io := ledSink.bundle // could/should put OBUFs here?
 
     val cutAt = boardPins.size
     val ios = IOPin.of(io)

--- a/src/main/scala/shell/xilinx/VC707Shell.scala
+++ b/src/main/scala/shell/xilinx/VC707Shell.scala
@@ -371,7 +371,7 @@ trait HasVC707ChipLink { this: VC707Shell =>
     )
   }
 
-  def connectChipLink(dut: { val chiplink: HeterogeneousBag[WideDataLayerPort] } , iofpga: Boolean = false): Unit = {
+  def connectChipLink(dut: { val chiplink: Seq[WideDataLayerPort] } , iofpga: Boolean = false): Unit = {
     constrainChipLink(iofpga)
 
     chiplink <> dut.chiplink(0)


### PR DESCRIPTION
We removed the `BundleBridge` wrapper, so some shells now have to use the source and sink nodes directly. This adds the equivalent nodes in the overlay.

