### PR TITLE
VC707Shell: default to 1GB of RAM (what the board ships with)

### DIFF
--- a/src/main/scala/shell/xilinx/VC707NewShell.scala
+++ b/src/main/scala/shell/xilinx/VC707NewShell.scala
@@ -119,7 +119,7 @@ class JTAGDebugVC707Overlay(val shell: VC707Shell, val name: String, params: JTA
   } }
 }
 
-case object VC707DDRSize extends Field[BigInt](0x40000000L * 4) // 4GB
+case object VC707DDRSize extends Field[BigInt](0x40000000L * 1) // 1GB
 class DDRVC707Overlay(val shell: VC707Shell, val name: String, params: DDROverlayParams)
   extends DDROverlay[XilinxVC707MIGPads](params)
 {


### PR DESCRIPTION
While 4GB chips are possible, they should not be the default!