### PR TITLE
Make some of the connector methods more flexible

### DIFF
--- a/src/main/scala/shell/xilinx/VC707Shell.scala
+++ b/src/main/scala/shell/xilinx/VC707Shell.scala
@@ -64,7 +64,7 @@ trait HasDebugJTAG { this: VC707Shell =>
   val jtag_TDI             = IO(Input(Bool()))
   val jtag_TDO             = IO(Output(Bool()))
 
-  def connectDebugJTAG(dut: HasPeripheryDebugModuleImp, fmcxm105: Boolean = true): SystemJTAGIO = {
+  def connectDebugJTAG(djtag: SystemJTAGIO, fmcxm105: Boolean, ndreset: Bool): SystemJTAGIO = {
   
     ElaborationArtefacts.add(
     """debugjtag.vivado.tcl""",
@@ -108,8 +108,6 @@ trait HasDebugJTAG { this: VC707Shell =>
       )
     }
    
-    val djtag     = dut.debug.systemjtag.get
-
     djtag.jtag.TCK := jtag_TCK
     djtag.jtag.TMS := jtag_TMS
     djtag.jtag.TDI := jtag_TDI
@@ -118,9 +116,14 @@ trait HasDebugJTAG { this: VC707Shell =>
     djtag.mfr_id   := p(JtagDTMKey).idcodeManufId.U(11.W)
 
     djtag.reset    := PowerOnResetFPGAOnly(dut_clock)
-    dut_ndreset    := dut.debug.ndreset
+    dut_ndreset    := ndreset
     djtag
   }
+
+
+  def connectDebugJTAG(dut: HasPeripheryDebugModuleImp, fmcxm105: Boolean = true): SystemJTAGIO =
+    connectDebugJTAG(dut.debug.systemjtag.get, fmcxm105, dut.debug.ndreset)
+
 }
 
 trait HasVC707ChipLink { this: VC707Shell =>
@@ -558,25 +561,27 @@ abstract class VC707Shell(implicit val p: Parameters) extends RawModule {
 
   uart_rtsn := false.B
 
-  def connectUART(dut: HasPeripheryUARTModuleImp): Unit = {
-    val uartParams = p(PeripheryUARTKey)
-    if (!uartParams.isEmpty) {
-      // uart connections
-      dut.uart(0).rxd := SyncResetSynchronizerShiftReg(uart_rx, 2, init = Bool(true), name=Some("uart_rxd_sync"))
-      uart_tx         := dut.uart(0).txd
-    }
+  def connectUART(dut: HasPeripheryUARTModuleImp): Unit =
+    dut.uart.lift(0).map { connectUART(_)}
+
+  def connectUART(uart: UARTPortIO): Unit = {
+    uart.rxd := SyncResetSynchronizerShiftReg(uart_rx, 2, init = Bool(true), name=Some("uart_rxd_sync"))
+    uart_tx  := uart.txd
   }
+
 
   //-----------------------------------------------------------------------
   // SPI
   //-----------------------------------------------------------------------
-
   def connectSPI(dut: HasPeripherySPIModuleImp): Unit = {
+    dut.spi.lift(0).map { connectSPI(_) }
+  }
+  def connectSPI(spi: SPIPortIO): Unit = {
     // SPI
-    sd_spi_sck := dut.spi(0).sck
-    sd_spi_cs  := dut.spi(0).cs(0)
+    sd_spi_sck := spi.sck
+    sd_spi_cs  := spi.cs(0)
 
-    dut.spi(0).dq.zipWithIndex.foreach {
+    spi.dq.zipWithIndex.foreach {
       case(pin, idx) =>
         sd_spi_dq_o(idx) := pin.o
         pin.i            := sd_spi_dq_i(idx)

--- a/src/main/scala/shell/xilinx/VC707Shell.scala
+++ b/src/main/scala/shell/xilinx/VC707Shell.scala
@@ -418,14 +418,14 @@ abstract class VC707Shell(implicit val p: Parameters) extends RawModule {
   val btn_3                = IO(Analog(1.W))
 
   //Sliding switches
-  val sw_0                 = IO(Analog(1.W))
-  val sw_1                 = IO(Analog(1.W))
-  val sw_2                 = IO(Analog(1.W))
-  val sw_3                 = IO(Analog(1.W))
-  val sw_4                 = IO(Analog(1.W))
-  val sw_5                 = IO(Analog(1.W))
-  val sw_6                 = IO(Analog(1.W))
-  val sw_7                 = IO(Analog(1.W))
+  val sw_0                 = IO(Input(Bool()))
+  val sw_1                 = IO(Input(Bool()))
+  val sw_2                 = IO(Input(Bool()))
+  val sw_3                 = IO(Input(Bool()))
+  val sw_4                 = IO(Input(Bool()))
+  val sw_5                 = IO(Input(Bool()))
+  val sw_6                 = IO(Input(Bool()))
+  val sw_7                 = IO(Input(Bool()))
 
 
   //-----------------------------------------------------------------------

--- a/src/main/scala/shell/xilinx/VC707Shell.scala
+++ b/src/main/scala/shell/xilinx/VC707Shell.scala
@@ -418,14 +418,14 @@ abstract class VC707Shell(implicit val p: Parameters) extends RawModule {
   val btn_3                = IO(Analog(1.W))
 
   //Sliding switches
-  val sw_0                 = IO(Input(Bool()))
-  val sw_1                 = IO(Input(Bool()))
-  val sw_2                 = IO(Input(Bool()))
-  val sw_3                 = IO(Input(Bool()))
-  val sw_4                 = IO(Input(Bool()))
-  val sw_5                 = IO(Input(Bool()))
-  val sw_6                 = IO(Input(Bool()))
-  val sw_7                 = IO(Input(Bool()))
+  val sw_0                 = IO(Analog(1.W))
+  val sw_1                 = IO(Analog(1.W))
+  val sw_2                 = IO(Analog(1.W))
+  val sw_3                 = IO(Analog(1.W))
+  val sw_4                 = IO(Analog(1.W))
+  val sw_5                 = IO(Analog(1.W))
+  val sw_6                 = IO(Analog(1.W))
+  val sw_7                 = IO(Analog(1.W))
 
 
   //-----------------------------------------------------------------------


### PR DESCRIPTION
Right now the connector methods assume a `dut` with some specific periphery mixins, but really we just care about the actual port that needs to be connected to, so provide methods that allow that.
The old connector methods remain the same.