### PR TITLE
connectSPI and connectUART no longer require entire dut

### DIFF
--- a/src/main/scala/shell/microsemi/PolarFireEvalKitShell.scala
+++ b/src/main/scala/shell/microsemi/PolarFireEvalKitShell.scala
@@ -633,27 +633,26 @@ abstract class PolarFireEvalKitShell(implicit val p: Parameters) extends RawModu
   // UART
   //-----------------------------------------------------------------------
 
-  def connectUART(dut: HasPeripheryUARTModuleImp): Unit = {
-    val uartParams = p(PeripheryUARTKey)
-    if (!uartParams.isEmpty) {
-      // uart connections
-      dut.uart(0).rxd := SyncResetSynchronizerShiftReg(uart_rx, 2, init = Bool(true), name=Some("uart_rxd_sync"))
-      uart_tx         := dut.uart(0).txd
-    }
+  def connectUART(dut: HasPeripheryUARTModuleImp): Unit = dut.uart.headOption.foreach(connectUART)
+
+  def connectUART(uart: UARTPortIO): Unit = {
+    uart.rxd := SyncResetSynchronizerShiftReg(uart_rx, 2, init = Bool(true), name=Some("uart_rxd_sync"))
+    uart_tx      := uart.txd
   }
 
   //-----------------------------------------------------------------------
   // SPI
   //-----------------------------------------------------------------------
 
-  def connectSPI(dut: HasPeripherySPIModuleImp): Unit = {
-    // SPI
+  def connectSPI(dut: HasPeripherySPIModuleImp): Unit = dut.spi.headOption.foreach(connectSPI)
+
+  def connectSPI(spi: SPIPortIO): Unit = {
     spi_flash_reset := fpga_reset
     spi_flash_wp    := UInt("b0")
     spi_flash_hold  := UInt("b0")
-    spi_flash_sck   := dut.spi(0).sck
-    spi_flash_ss    := dut.spi(0).cs(0)
-    spi_flash_sdo   := dut.spi(0).dq(0).o
-    dut.spi(0).dq(0).i := spi_flash_sdi
+    spi_flash_sck   := spi.sck
+    spi_flash_ss    := spi.cs(0)
+    spi_flash_sdo   := spi.dq(0).o
+    spi.dq(0).i := spi_flash_sdi
   }
 }

--- a/src/main/scala/shell/xilinx/VC707Shell.scala
+++ b/src/main/scala/shell/xilinx/VC707Shell.scala
@@ -558,25 +558,25 @@ abstract class VC707Shell(implicit val p: Parameters) extends RawModule {
 
   uart_rtsn := false.B
 
-  def connectUART(dut: HasPeripheryUARTModuleImp): Unit = {
-    val uartParams = p(PeripheryUARTKey)
-    if (!uartParams.isEmpty) {
-      // uart connections
-      dut.uart(0).rxd := SyncResetSynchronizerShiftReg(uart_rx, 2, init = Bool(true), name=Some("uart_rxd_sync"))
-      uart_tx         := dut.uart(0).txd
-    }
+  def connectUART(dut: HasPeripheryUARTModuleImp): Unit = dut.uart.headOption.foreach(connectUART)
+
+  def connectUART(uart: UARTPortIO): Unit = {
+    uart.rxd := SyncResetSynchronizerShiftReg(uart_rx, 2, init = Bool(true), name=Some("uart_rxd_sync"))
+    uart_tx  := uart.txd
   }
 
   //-----------------------------------------------------------------------
   // SPI
   //-----------------------------------------------------------------------
 
-  def connectSPI(dut: HasPeripherySPIModuleImp): Unit = {
-    // SPI
-    sd_spi_sck := dut.spi(0).sck
-    sd_spi_cs  := dut.spi(0).cs(0)
+  def connectSPI(dut: HasPeripherySPIModuleImp): Unit = dut.spi.headOption.foreach(connectSPI)
 
-    dut.spi(0).dq.zipWithIndex.foreach {
+  def connectSPI(spi: SPIPortIO): Unit = {
+    // SPI
+    sd_spi_sck := spi.sck
+    sd_spi_cs  := spi.cs(0)
+
+    spi.dq.zipWithIndex.foreach {
       case(pin, idx) =>
         sd_spi_dq_o(idx) := pin.o
         pin.i            := sd_spi_dq_i(idx)

--- a/src/main/scala/shell/xilinx/VCU118Shell.scala
+++ b/src/main/scala/shell/xilinx/VCU118Shell.scala
@@ -226,25 +226,25 @@ abstract class VCU118Shell(implicit val p: Parameters) extends RawModule {
 
   uart_rtsn := false.B
 
-  def connectUART(dut: HasPeripheryUARTModuleImp): Unit = {
-    val uartParams = p(PeripheryUARTKey)
-    if (!uartParams.isEmpty) {
-      // uart connections
-      dut.uart(0).rxd := SyncResetSynchronizerShiftReg(uart_rx, 2, init = Bool(true), name=Some("uart_rxd_sync"))
-      uart_tx         := dut.uart(0).txd
-    }
+  def connectUART(dut: HasPeripheryUARTModuleImp): Unit = dut.uart.headOption.foreach(connectUART)
+
+  def connectUART(uart: UARTPortIO): Unit = {
+    uart.rxd := SyncResetSynchronizerShiftReg(uart_rx, 2, init = Bool(true), name=Some("uart_rxd_sync"))
+    uart_tx  := uart.txd
   }
 
   //-----------------------------------------------------------------------
   // SPI
   //-----------------------------------------------------------------------
 
-  def connectSPI(dut: HasPeripherySPIModuleImp): Unit = {
-    // SPI
-    sd_spi_sck := dut.spi(0).sck
-    sd_spi_cs  := dut.spi(0).cs(0)
+  def connectSPI(dut: HasPeripherySPIModuleImp): Unit = dut.spi.headOption.foreach(connectSPI)
 
-    dut.spi(0).dq.zipWithIndex.foreach {
+  def connectSPI(spi: SPIPortIO): Unit = {
+    // SPI
+    sd_spi_sck := spi.sck
+    sd_spi_cs  := spi.cs(0)
+
+    spi.dq.zipWithIndex.foreach {
       case(pin, idx) =>
         sd_spi_dq_o(idx) := pin.o
         pin.i            := sd_spi_dq_i(idx)


### PR DESCRIPTION
It's more future-proof to operate on the specific bundle and param instances required instead of expecting a specific trait of a specific hierarchy level.

Future work:
- eliminate further dependencies on similar traits (Debug (#41), XilinxMIG)
- standardize dut_clock and dut_reset so they're always available, or some other way to make sure that the right clock is used for each peripheral's connection wiring