### PR TITLE
Move JTAG to LCD connector

### DIFF
--- a/src/main/scala/shell/xilinx/VC707NewShell.scala
+++ b/src/main/scala/shell/xilinx/VC707NewShell.scala
@@ -106,11 +106,29 @@ class JTAGDebugVC707Overlay(val shell: VC707Shell, val name: String, params: JTA
     shell.sdc.addClock("JTCK", IOPin(io.jtag_TCK), 10)
     shell.sdc.addGroup(clocks = Seq("JTCK"))
     shell.xdc.clockDedicatedRouteFalse(IOPin(io.jtag_TCK))
+/* if old method
     val packagePinsWithPackageIOs = Seq(("R32", IOPin(io.jtag_TCK)),
                                         ("W36", IOPin(io.jtag_TMS)),
                                         ("W37", IOPin(io.jtag_TDI)),
                                         ("V40", IOPin(io.jtag_TDO)))
-
+*/
+    /*
+           #Olimex Pin  Olimex Function LCD Pin LCD Function FPGA Pin
+           #1           VREF            14      5V
+           #3           TTRST_N         1       LCD_DB7       AN40
+           #5           TTDI            2       LCD_DB6       AR39
+           #7           TTMS            3       LCD_DB5       AR38
+           #9           TTCK            4       LCD_DB4       AT42
+           #11          TRTCK           NC      NC            NC
+           #13          TTDO            9       LCD_E         AT40
+           #15          TSRST_N         10      LCD_RW        AR42
+           #2           VREF            14      5V
+           #18          GND             13      GND
+     */
+    val packagePinsWithPackageIOs = Seq(("AT42", IOPin(io.jtag_TCK)),
+                                        ("AR38", IOPin(io.jtag_TMS)),
+                                        ("AR39", IOPin(io.jtag_TDI)),
+                                        ("AT40", IOPin(io.jtag_TDO)))
     packagePinsWithPackageIOs foreach { case (pin, io) => {
       shell.xdc.addPackagePin(io, pin)
       shell.xdc.addIOStandard(io, "LVCMOS18")


### PR DESCRIPTION
Put JTAG for VC707 on the LCD connector, instead of an add-on board.

needs review for conflicts and testing of what happens if the LCD is installed. 