### PR TITLE
remove api-generator-sifive dependency

### DIFF
--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,10 +1,5 @@
 [
     {
-        "commit": "50b9d6ffdfbff683fa25045d7f1ef3585a34f2dc",
-        "name": "api-generator-sifive",
-        "source": "git@github.com:sifive/api-generator-sifive.git"
-    },
-    {
         "commit": "4374e58fc282f9670605ce5a741436d18242e520",
         "name": "sifive-blocks",
         "source": "git@github.com:sifive/sifive-blocks.git"


### PR DESCRIPTION
`fpga-shells` doesn't actually use anything from `api-generator-sifive`. `api-generator-sifive` pulls in a lot of stuff so it would be really helpful for repos that depend on `fpga-shells` if this  dependency was removed.