### PR TITLE
Revert "Revert "SPI speedup related FPGA changes""

### DIFF
--- a/src/main/scala/shell/xilinx/ArtyShell.scala
+++ b/src/main/scala/shell/xilinx/ArtyShell.scala
@@ -170,7 +170,7 @@ abstract class ArtyShell(implicit val p: Parameters) extends RawModule {
         dut.qspi(0),
         dut.clock,
         dut.reset,
-        syncStages = qspi_params.sampleDelay
+        syncStages = qspi_params.defaultSampleDel
       )
 
       IOBUF(qspi_sck, dut.qspi(0).sck)

--- a/xilinx/vc707/constraints/vc707-master.xdc
+++ b/xilinx/vc707/constraints/vc707-master.xdc
@@ -1,3 +1,6 @@
 #-------------- MCS Generation ----------------------
 set_property CFGBVS GND                               [current_design]
 set_property CONFIG_VOLTAGE 1.8                       [current_design]
+
+set_property EXTRACT_ENABLE YES                       [get_cells dut_/spi_0_1/mac/phy/txd_reg*]
+set_property EXTRACT_ENABLE YES                       [get_cells dut_/spi_0_1/mac/phy/sck_reg]

--- a/xilinx/vc707/vsrc/sdio.v
+++ b/xilinx/vc707/vsrc/sdio.v
@@ -17,8 +17,7 @@ module sdio_spi_bridge (
 );
 
   wire mosi, miso;
-  reg miso_sync [1:0];
-
+(* extract_reset = "yes" *) reg miso_sync [1:0];
   assign mosi = spi_dq_o[0];
   assign spi_dq_i = {2'b00, miso_sync[1], 1'b0};
 


### PR DESCRIPTION
This change slipped away when I made the PR https://github.com/sifive/fpga-shells/pull/64.
This change is required for the PR https://github.com/sifive/freedom/pull/118 to avoid the following build error.
``` 
[error] /home/user/freedom/fpga-shells/src/main/scala/shell/xilinx/ArtyShell.scala:173:34: value sampleDelay is not a member of sifive.blocks.devices.spi.SPIFlashParams
[error] Error occurred in an application involving default arguments.
[error]         syncStages = qspi_params.sampleDelay
[error]                                  ^
[error] one error found
[error] (fpgaShells / Compile / compileIncremental) Compilation failed
```