### PR TITLE
Overlays: Analog, change top-level io connectivity

### DIFF
--- a/src/main/scala/shell/GPIOOverlay.scala
+++ b/src/main/scala/shell/GPIOOverlay.scala
@@ -12,17 +12,17 @@ import chisel3.experimental._
 case class GPIOOverlayParams(gpioParam: GPIOParams, controlBus: TLBusWrapper, intNode: IntInwardNode)(implicit val p: Parameters)
 case object GPIOOverlayKey extends Field[Seq[DesignOverlay[GPIOOverlayParams, TLGPIO]]](Nil)
 
-class FPGAGPIOPortIO(width: Int = 4) extends Bundle {
+class ShellGPIOPortIO(width: Int = 4) extends Bundle {
   val gpio = Vec(width, Analog(1.W))
 }
 
 abstract class GPIOOverlay(
   val params: GPIOOverlayParams)
-    extends IOOverlay[FPGAGPIOPortIO, TLGPIO]
+    extends IOOverlay[ShellGPIOPortIO, TLGPIO]
 {
   implicit val p = params.p
 
-  def ioFactory = new FPGAGPIOPortIO(params.gpioParam.width)
+  def ioFactory = new ShellGPIOPortIO(params.gpioParam.width)
   val tlgpio = GPIO.attach(GPIOAttachParams(params.gpioParam, params.controlBus, params.intNode))
 
   val tlgpioSink = shell { tlgpio.ioNode.makeSink }

--- a/src/main/scala/shell/GPIOOverlay.scala
+++ b/src/main/scala/shell/GPIOOverlay.scala
@@ -27,11 +27,4 @@ abstract class GPIOOverlay(
 
   val tlgpioSink = shell { tlgpio.ioNode.makeSink }
   val designOutput = tlgpio
-
-  shell { InModuleBody {
-      tlgpioSink.bundle.pins.zipWithIndex.foreach{ case (tlpin, idx) => {
-        UIntToAnalog(tlpin.o.oval, io.gpio(idx), tlpin.o.oe)
-        tlpin.i.ival := AnalogToUInt(io.gpio(idx))
-      } }
-  } }
 }

--- a/src/main/scala/shell/I2COverlay.scala
+++ b/src/main/scala/shell/I2COverlay.scala
@@ -30,12 +30,4 @@ abstract class I2COverlay(
   val tli2cSink = shell { tli2c.ioNode.makeSink }
 
   val designOutput = tli2c
-
-  shell { InModuleBody {
-    UIntToAnalog(tli2cSink.bundle.scl.out, io.scl, tli2cSink.bundle.scl.oe)
-    UIntToAnalog(tli2cSink.bundle.sda.out, io.sda, tli2cSink.bundle.sda.oe)
-
-    tli2cSink.bundle.scl.in := AnalogToUInt(io.scl)
-    tli2cSink.bundle.sda.in := AnalogToUInt(io.sda)
-  } }
 }

--- a/src/main/scala/shell/JTAGDebugOverlay.scala
+++ b/src/main/scala/shell/JTAGDebugOverlay.scala
@@ -2,38 +2,36 @@
 package sifive.fpgashells.shell
 
 import chisel3._
+import chisel3.experimental._
 import freechips.rocketchip.config._
 import freechips.rocketchip.util._
 import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.jtag._
 import freechips.rocketchip.devices.debug._
 import freechips.rocketchip.subsystem.{BaseSubsystem, PeripheryBus, PeripheryBusKey}
 import sifive.fpgashells.ip.xilinx._
 
 case class JTAGDebugOverlayParams()(implicit val p: Parameters)
-case object JTAGDebugOverlayKey extends Field[Seq[DesignOverlay[JTAGDebugOverlayParams, ModuleValue[FPGAJTAGIO]]]](Nil)
+case object JTAGDebugOverlayKey extends Field[Seq[DesignOverlay[JTAGDebugOverlayParams, ModuleValue[JTAGIO]]]](Nil)
 
-class FPGAJTAGIO extends Bundle {
+class ShellJTAGIO extends Bundle {
   // JTAG
-  val jtag_TCK = Input(Clock())
-  val jtag_TMS = Input(Bool())
-  val jtag_TDI = Input(Bool())
-  val jtag_TDO = Output(Bool())
+  val jtag_TCK = Analog(1.W)
+  val jtag_TMS = Analog(1.W)
+  val jtag_TDI = Analog(1.W)
+  val jtag_TDO = Analog(1.W)
 }
 
 abstract class JTAGDebugOverlay(
   val params: JTAGDebugOverlayParams)
-    extends IOOverlay[FPGAJTAGIO, ModuleValue[FPGAJTAGIO]]
+    extends IOOverlay[ShellJTAGIO, ModuleValue[JTAGIO]]
 {
   implicit val p = params.p
 
-  def ioFactory = new FPGAJTAGIO
+  def ioFactory = new ShellJTAGIO
 
-  val jtagDebugSource = BundleBridgeSource(() => new FPGAJTAGIO)
+  val jtagDebugSource = BundleBridgeSource(() => new JTAGIO())
   val jtagDebugSink = shell { jtagDebugSource.makeSink }
 
   val designOutput = InModuleBody { jtagDebugSource.bundle}
-
-  shell { InModuleBody {
-    io <> jtagDebugSink.bundle
-  } }
 }

--- a/src/main/scala/shell/PWMOverlay.scala
+++ b/src/main/scala/shell/PWMOverlay.scala
@@ -13,30 +13,20 @@ import freechips.rocketchip.interrupts.IntInwardNode
 case class PWMOverlayParams(pwmParams: PWMParams, controlBus: TLBusWrapper, intNode: IntInwardNode)(implicit val p: Parameters)
 case object PWMOverlayKey extends Field[Seq[DesignOverlay[PWMOverlayParams, TLPWM]]](Nil)
 
-class FPGAPWMPortIO extends Bundle {
-  val pwm_gpio_0 = Output(Bool())
-  val pwm_gpio_1 = Output(Bool())
-  val pwm_gpio_2 = Output(Bool())
-  val pwm_gpio_3 = Output(Bool())
+class ShellPWMPortIO extends Bundle {
+  val pwm_gpio = Vec(4, Analog(1.W))
 }
 
 abstract class PWMOverlay(
   val params: PWMOverlayParams)
-    extends IOOverlay[FPGAPWMPortIO, TLPWM]
+    extends IOOverlay[ShellPWMPortIO, TLPWM]
 {
   implicit val p = params.p
 
-  def ioFactory = new FPGAPWMPortIO
+  def ioFactory = new ShellPWMPortIO
 
   val tlpwm = PWM.attach(PWMAttachParams(params.pwmParams, params.controlBus, params.intNode))
   val tlpwmSink = shell { tlpwm.ioNode.makeSink }
 
   val designOutput = tlpwm
-
-  shell { InModuleBody {
-    io.pwm_gpio_0 := tlpwmSink.bundle.gpio(0)
-    io.pwm_gpio_1 := tlpwmSink.bundle.gpio(1)
-    io.pwm_gpio_2 := tlpwmSink.bundle.gpio(2)
-    io.pwm_gpio_3 := tlpwmSink.bundle.gpio(3)
-  } }
 }

--- a/src/main/scala/shell/PinOverlay.scala
+++ b/src/main/scala/shell/PinOverlay.scala
@@ -1,0 +1,35 @@
+// See LICENSE for license details.
+package sifive.fpgashells.shell
+
+import chisel3._
+import freechips.rocketchip.config._
+import freechips.rocketchip.diplomacy._
+import sifive.blocks.devices.gpio._
+import freechips.rocketchip.tilelink.TLBusWrapper
+import freechips.rocketchip.interrupts.IntInwardNode
+import chisel3.experimental._
+
+case class PinOverlayParams()(implicit val p: Parameters)
+case object PinOverlayKey extends Field[Seq[DesignOverlay[PinOverlayParams, ModuleValue[PinPortIO]]]](Nil)
+
+class PinPortIO extends Bundle {
+  val pins = Vec(8, Analog(1.W))
+}
+
+abstract class PinOverlay(
+  val params: PinOverlayParams)
+    extends IOOverlay[PinPortIO, ModuleValue[PinPortIO]]
+{
+  implicit val p = params.p
+
+  def ioFactory = new PinPortIO
+
+  val pinSource = BundleBridgeSource(() => new PinPortIO)
+  val pinSink = shell { pinSource.makeSink }
+
+  val designOutput = InModuleBody { pinSource.bundle }
+
+  shell { InModuleBody {
+    io <> pinSink.bundle
+  }}
+}

--- a/src/main/scala/shell/SPIFlashOverlay.scala
+++ b/src/main/scala/shell/SPIFlashOverlay.scala
@@ -13,40 +13,21 @@ case class SPIFlashOverlayParams(spiFlashParam: SPIFlashParams, controlBus: TLBu
 case object SPIFlashOverlayKey extends Field[Seq[DesignOverlay[SPIFlashOverlayParams, TLSPIFlash]]](Nil)
 
 
-class FPGASPIFlashPortIO extends Bundle {
-  val qspi_sck  = Output(Bool())
-  val qspi_cs   = Output(Bool())
-  val qspi_dq_0 = Analog(1.W)
-  val qspi_dq_1 = Analog(1.W)
-  val qspi_dq_2 = Analog(1.W)
-  val qspi_dq_3 = Analog(1.W)
+class ShellSPIFlashPortIO extends Bundle {
+  val qspi_sck = Analog(1.W)
+  val qspi_cs  = Analog(1.W)
+  val qspi_dq  = Vec(4, Analog(1.W))
 }
 
 abstract class SPIFlashOverlay(
   val params: SPIFlashOverlayParams)
-    extends IOOverlay[FPGASPIFlashPortIO, TLSPIFlash]
+    extends IOOverlay[ShellSPIFlashPortIO, TLSPIFlash]
 {
   implicit val p = params.p
 
-  def ioFactory = new FPGASPIFlashPortIO
+  def ioFactory = new ShellSPIFlashPortIO
   val tlqspi = SPI.attachFlash(SPIFlashAttachParams(params.spiFlashParam, params.controlBus, params.memBus, params.intNode))
 
   val tlqspiSink = shell { tlqspi.ioNode.makeSink }
   val designOutput = tlqspi
-
-  shell { InModuleBody {
-    io.qspi_sck := tlqspiSink.bundle.sck
-    io.qspi_cs  := tlqspiSink.bundle.cs(0)
-
-    UIntToAnalog(tlqspiSink.bundle.dq(0).o, io.qspi_dq_0, tlqspiSink.bundle.dq(0).oe)
-    UIntToAnalog(tlqspiSink.bundle.dq(1).o, io.qspi_dq_1, tlqspiSink.bundle.dq(1).oe)
-    UIntToAnalog(tlqspiSink.bundle.dq(2).o, io.qspi_dq_2, tlqspiSink.bundle.dq(2).oe)
-    UIntToAnalog(tlqspiSink.bundle.dq(3).o, io.qspi_dq_3, tlqspiSink.bundle.dq(3).oe)
-
-    tlqspiSink.bundle.dq(0).i := AnalogToUInt(io.qspi_dq_0)
-    tlqspiSink.bundle.dq(1).i := AnalogToUInt(io.qspi_dq_1)
-    tlqspiSink.bundle.dq(2).i := AnalogToUInt(io.qspi_dq_2)
-    tlqspiSink.bundle.dq(3).i := AnalogToUInt(io.qspi_dq_3)
-
-  } }
 }

--- a/src/main/scala/shell/Shell.scala
+++ b/src/main/scala/shell/Shell.scala
@@ -13,21 +13,6 @@ import firrtl.annotations._
 import freechips.rocketchip.util.DontTouch
 case object DesignKey extends Field[Parameters => LazyModule]
 
-trait MarkDUT extends DontTouch {
-  self: RawModule =>
-  /** Marks this Module as the DUT
-    *
-    * @note This also marks all ports of the Module as don't touch
-    * @note This method can only be called after the Module has been fully constructed
-    *   (after Module(...))
-    */
-  def markDUT(): this.type = {
-    self.dontTouchPorts()
-    chisel3.experimental.annotate(new ChiselAnnotation { def toFirrtl = MarkDUTAnnotation(self.toNamed) })
-    self
-  }
-}
-
 // Overlays are declared by the Shell and placed somewhere by the Design
 // ... they inject diplomatic code both where they were placed and in the shell
 // ... they are instantiated with DesignInput and return DesignOutput
@@ -79,39 +64,4 @@ abstract class Shell()(implicit p: Parameters) extends LazyModule with LazyScope
 
   // feel free to override this if necessary
   lazy val module = new LazyRawModuleImp(this)
-}
-
-case class MarkDUTAnnotation(target: ModuleName) extends SingleTargetAnnotation[ModuleName] {
-  def duplicate(n: ModuleName): MarkDUTAnnotation = MarkDUTAnnotation(n)
-}
-
-/** Contains helper methods for finding things relative to the DUT while running other transforms */
-object MarkDUTAnnotation {
-  /** Find names of all [[DefModule]]s in the DUT
-    * Throws exception if no MarkDUTAnnotation found
-    * @return (Name of DUT Top, names of other DefModules in the DUT)
-    */
-  def getDUTModules(state: CircuitState): (String, Set[String]) =
-    getDUTModules(state, new InstanceGraph(state.circuit))
-  def getDUTModules(state: CircuitState, igraph: => InstanceGraph): (String, Set[String]) =
-    getDUTModulesOpt(state, igraph).getOrElse(
-      throw new Exception("Attemping to find all Modules in DUT but no MarkDUTAnnotation found!")
-    )
-
-  /** Find names of all [[DefModule]]s in the DUT if annotation found, None otherwise
-    * @return Option(Name of DUT Top, names of other DefModules in the DUT)
-    */
-  def getDUTModulesOpt(state: CircuitState): Option[(String, Set[String])] =
-    getDUTModulesOpt(state, new InstanceGraph(state.circuit))
-  def getDUTModulesOpt(state: CircuitState, igraph: => InstanceGraph): Option[(String, Set[String])] =
-    state.annotations.collect { case MarkDUTAnnotation(ModuleName(dutTop, _)) => dutTop } match {
-      case Seq() => None
-      case Seq(dutTop) =>
-        val mgraph = igraph.graph.transformNodes(_.module)
-        require(mgraph.contains(dutTop),
-          s"MarkDUTAnnotation found but $dutTop does not exist in circuit!")
-        Some((dutTop, mgraph.reachableFrom(dutTop).toSet))
-      case duts =>
-        throw new Exception(s"Error! More than one DUT specified: " + duts.mkString(", "))
-  }
 }

--- a/src/main/scala/shell/UARTOverlay.scala
+++ b/src/main/scala/shell/UARTOverlay.scala
@@ -2,6 +2,7 @@
 package sifive.fpgashells.shell
 
 import chisel3._
+import chisel3.experimental._
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 import sifive.blocks.devices.uart._
@@ -15,20 +16,22 @@ case object UARTOverlayKey extends Field[Seq[DesignOverlay[UARTOverlayParams, TL
 
 // Tack on cts, rts signals available on some FPGAs. They are currently unused
 // by our designs.
-class FPGAUARTPortIO(flowControl: Boolean) extends UARTPortIO {
-  val rtsn = if (flowControl) Some(Output(Bool())) else None
-  val ctsn = if (flowControl) Some(Input(Bool())) else None
+class ShellUARTPortIO(flowControl: Boolean) extends Bundle {
+  val txd = Analog(1.W)
+  val rxd = Analog(1.W)
+  val rtsn = if (flowControl) Some(Analog(1.W)) else None
+  val ctsn = if (flowControl) Some(Analog(1.W)) else None
 }
 
 //class UARTReplacementBundle extends Bundle with HasUARTTopBundleContents
 
 abstract class UARTOverlay(
   val params: UARTOverlayParams, flowControl: Boolean)
-    extends IOOverlay[FPGAUARTPortIO, TLUART]
+    extends IOOverlay[ShellUARTPortIO, TLUART]
 {
   implicit val p = params.p
 
-  def ioFactory = new FPGAUARTPortIO(flowControl)
+  def ioFactory = new ShellUARTPortIO(flowControl)
 
   val tluart = UART.attach(UARTAttachParams(params.uartParams, params.divInit, params.controlBus, params.intNode))
   val tluartSink = tluart.ioNode.makeSink
@@ -36,16 +39,4 @@ abstract class UARTOverlay(
   val uartSink = shell { uartSource.makeSink }
 
   val designOutput = tluart
-
-  InModuleBody {
-    val (io, _) = uartSource.out(0)
-    val tluartport = tluartSink.bundle
-    io <> tluartport
-    tluartport.rxd := RegNext(RegNext(io.rxd))
-  }
-
-  shell { InModuleBody {
-    io.txd := uartSink.bundle.txd
-    uartSink.bundle.rxd := io.rxd
-  } }
 }

--- a/src/main/scala/shell/xilinx/Arty100TShell.scala
+++ b/src/main/scala/shell/xilinx/Arty100TShell.scala
@@ -54,10 +54,10 @@ class SPIFlashArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: Strin
   shell { InModuleBody {
     val packagePinsWithPackageIOs = Seq(("L16", IOPin(io.qspi_sck)),
       ("L13", IOPin(io.qspi_cs)),
-      ("K17", IOPin(io.qspi_dq_0)),
-      ("K18", IOPin(io.qspi_dq_1)),
-      ("L14", IOPin(io.qspi_dq_2)),
-      ("M14", IOPin(io.qspi_dq_3)))
+      ("K17", IOPin(io.qspi_dq(0))),
+      ("K18", IOPin(io.qspi_dq(1))),
+      ("L14", IOPin(io.qspi_dq(2))),
+      ("M14", IOPin(io.qspi_dq(3))))
 
     packagePinsWithPackageIOs foreach { case (pin, io) => {
       shell.xdc.addPackagePin(io, pin)

--- a/src/main/scala/shell/xilinx/GPIOXilinxOverlay.scala
+++ b/src/main/scala/shell/xilinx/GPIOXilinxOverlay.scala
@@ -10,4 +10,11 @@ abstract class GPIOXilinxOverlay(params: GPIOOverlayParams)
   extends GPIOOverlay(params)
 {
   def shell: XilinxShell
+
+  shell { InModuleBody {
+      tlgpioSink.bundle.pins.zipWithIndex.foreach{ case (tlpin, idx) => {
+        UIntToAnalog(tlpin.o.oval, io.gpio(idx), tlpin.o.oe)
+        tlpin.i.ival := AnalogToUInt(io.gpio(idx))
+      } }
+  } }
 }

--- a/src/main/scala/shell/xilinx/I2COverlay.scala
+++ b/src/main/scala/shell/xilinx/I2COverlay.scala
@@ -10,4 +10,12 @@ import sifive.fpgashells.ip.xilinx._
   extends I2COverlay(params)
 {
   def shell: XilinxShell
+
+  shell { InModuleBody {
+    UIntToAnalog(tli2cSink.bundle.scl.out, io.scl, tli2cSink.bundle.scl.oe)
+    UIntToAnalog(tli2cSink.bundle.sda.out, io.sda, tli2cSink.bundle.sda.oe)
+
+    tli2cSink.bundle.scl.in := AnalogToUInt(io.scl)
+    tli2cSink.bundle.sda.in := AnalogToUInt(io.sda)
+  } }
 }

--- a/src/main/scala/shell/xilinx/JTAGDebugOverlay.scala
+++ b/src/main/scala/shell/xilinx/JTAGDebugOverlay.scala
@@ -12,7 +12,7 @@ abstract class JTAGDebugXilinxOverlay(params: JTAGDebugOverlayParams)
   def shell: XilinxShell
 
   shell { InModuleBody {
-    jtagDebugSink.bundle.TCK := AnalogToUInt(io.jtag_TCK)
+    jtagDebugSink.bundle.TCK := AnalogToUInt(io.jtag_TCK).asBool.asClock
     jtagDebugSink.bundle.TMS := AnalogToUInt(io.jtag_TMS)
     jtagDebugSink.bundle.TDI := AnalogToUInt(io.jtag_TDI)
     UIntToAnalog(jtagDebugSink.bundle.TDO.data,io.jtag_TDO,jtagDebugSink.bundle.TDO.driven)

--- a/src/main/scala/shell/xilinx/JTAGDebugOverlay.scala
+++ b/src/main/scala/shell/xilinx/JTAGDebugOverlay.scala
@@ -10,4 +10,11 @@ abstract class JTAGDebugXilinxOverlay(params: JTAGDebugOverlayParams)
   extends JTAGDebugOverlay(params)
 {
   def shell: XilinxShell
+
+  shell { InModuleBody {
+    jtagDebugSink.bundle.TCK := AnalogToUInt(io.jtag_TCK)
+    jtagDebugSink.bundle.TMS := AnalogToUInt(io.jtag_TMS)
+    jtagDebugSink.bundle.TDI := AnalogToUInt(io.jtag_TDI)
+    UIntToAnalog(jtagDebugSink.bundle.TDO.data,io.jtag_TDO,jtagDebugSink.bundle.TDO.driven)
+  } }
 }

--- a/src/main/scala/shell/xilinx/PWMOverlay.scala
+++ b/src/main/scala/shell/xilinx/PWMOverlay.scala
@@ -6,8 +6,14 @@ import freechips.rocketchip.diplomacy._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.xilinx._
 
- abstract class PWMXilinxOverlay(params: PWMOverlayParams)
+abstract class PWMXilinxOverlay(params: PWMOverlayParams)
   extends PWMOverlay(params)
 {
   def shell: XilinxShell
+
+  shell { InModuleBody {
+    tlpwmSink.bundle.gpio.zip(io.pwm_gpio).foreach { case(design_pwm, io_pwm) =>
+      io_pwm := design_pwm 
+    }
+  } }
 }

--- a/src/main/scala/shell/xilinx/PinXilinxOverlay.scala
+++ b/src/main/scala/shell/xilinx/PinXilinxOverlay.scala
@@ -1,0 +1,13 @@
+// See LICENSE for license details.
+package sifive.fpgashells.shell.xilinx
+
+import chisel3._
+import freechips.rocketchip.diplomacy._
+import sifive.fpgashells.shell._
+import sifive.fpgashells.ip.xilinx._
+
+abstract class PinXilinxOverlay(params: PinOverlayParams)
+  extends PinOverlay(params)
+{
+  def shell: XilinxShell
+}

--- a/src/main/scala/shell/xilinx/SPIFlashXilinxOverlay.scala
+++ b/src/main/scala/shell/xilinx/SPIFlashXilinxOverlay.scala
@@ -10,4 +10,14 @@ abstract class SPIFlashXilinxOverlay(params: SPIFlashOverlayParams)
   extends SPIFlashOverlay(params)
 {
   def shell: XilinxShell
+
+  shell { InModuleBody {
+    UIntToAnalog(tlqspiSink.bundle.sck  , io.qspi_sck, true.B)
+    UIntToAnalog(tlqspiSink.bundle.cs(0), io.qspi_cs , true.B)
+
+    tlqspiSink.bundle.dq.zip(io.qspi_dq).foreach { case(design_dq, io_dq) => 
+      UIntToAnalog(design_dq.o, io_dq, design_dq.oe)
+      design_dq.i := AnalogToUInt(io_dq)
+    }
+  } }
 }

--- a/src/main/scala/shell/xilinx/UARTOverlay.scala
+++ b/src/main/scala/shell/xilinx/UARTOverlay.scala
@@ -10,4 +10,16 @@ abstract class UARTXilinxOverlay(params: UARTOverlayParams, flowControl: Boolean
   extends UARTOverlay(params, flowControl)
 {
   def shell: XilinxShell
+
+  InModuleBody {
+    val (io, _) = uartSource.out(0)
+    val tluartport = tluartSink.bundle
+    io <> tluartport
+    tluartport.rxd := RegNext(RegNext(io.rxd))
+  }
+
+  shell { InModuleBody {
+    UIntToAnalog(uartSink.bundle.txd, io.txd, true.B)
+    uartSink.bundle.rxd := AnalogToUInt(io.rxd)
+  } }
 }

--- a/src/main/scala/shell/xilinx/VCU118NewShell.scala
+++ b/src/main/scala/shell/xilinx/VCU118NewShell.scala
@@ -70,10 +70,10 @@ class SPIFlashVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: Strin
   shell { InModuleBody { 
     val packagePinsWithPackageIOs = Seq(("AF13", IOPin(io.qspi_sck)),
       ("AJ11", IOPin(io.qspi_cs)),
-      ("AP11", IOPin(io.qspi_dq_0)),
-      ("AN11", IOPin(io.qspi_dq_1)),
-      ("AM11", IOPin(io.qspi_dq_2)),
-      ("AL11", IOPin(io.qspi_dq_3)))
+      ("AP11", IOPin(io.qspi_dq(0))),
+      ("AN11", IOPin(io.qspi_dq(1))),
+      ("AM11", IOPin(io.qspi_dq(2))),
+      ("AL11", IOPin(io.qspi_dq(3))))
 
     packagePinsWithPackageIOs foreach { case (pin, io) => {
       shell.xdc.addPackagePin(io, pin)


### PR DESCRIPTION
Change many overlay IO types to Analog and Vec in some cases. Move top-level io connectivity to subclasses to allow for use in ASIC designs