### PR TITLE
no pullup on keeper pin

### DIFF
--- a/src/main/scala/shell/xilinx/Arty100TShell.scala
+++ b/src/main/scala/shell/xilinx/Arty100TShell.scala
@@ -156,8 +156,9 @@ class cJTAGDebugArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: Str
     packagePinsWithPackageIOs foreach { case (pin, io) => {
       shell.xdc.addPackagePin(io, pin)
       shell.xdc.addIOStandard(io, "LVCMOS33")
-      shell.xdc.addPullup(io)
     } }
+      shell.xdc.addPullup(IOPin(io.cjtag_TCKC))
+      shell.xdc.addPullup(IOPin(io.srst_n))
   } }
 }
 


### PR DESCRIPTION
TMSC can't have both PULLUP and KEEPER, this removes pullup from it