### PR TITLE
Debug: Make Debug Module optional

### DIFF
--- a/src/main/scala/shell/xilinx/ArtyShell.scala
+++ b/src/main/scala/shell/xilinx/ArtyShell.scala
@@ -222,7 +222,7 @@ abstract class ArtyShell(implicit val p: Parameters) extends RawModule {
     dut_jtag_TDO   := djtag.jtag.TDO.data
 
     djtag.mfr_id   := p(JtagDTMKey).idcodeManufId.U(11.W)
-    djtag.pert_number := p(JtagDTMKey).idcodePartNum.U(16.W)
+    djtag.part_number := p(JtagDTMKey).idcodePartNum.U(16.W)
     djtag.version  := p(JtagDTMKey).idcodeVersion.U(4.W)
 
     djtag.reset    := dut_jtag_reset

--- a/src/main/scala/shell/xilinx/ArtyShell.scala
+++ b/src/main/scala/shell/xilinx/ArtyShell.scala
@@ -184,6 +184,7 @@ abstract class ArtyShell(implicit val p: Parameters) extends RawModule {
 
   def connectDebugJTAG(dut: HasPeripheryDebugModuleImp): SystemJTAGIO = {
 
+    require(dut.debug.ndreset.isDefined, "Connecting JTAG requires that debug module exists")
     //-------------------------------------------------------------------
     // JTAG Reset
     //-------------------------------------------------------------------
@@ -221,6 +222,8 @@ abstract class ArtyShell(implicit val p: Parameters) extends RawModule {
     dut_jtag_TDO   := djtag.jtag.TDO.data
 
     djtag.mfr_id   := p(JtagDTMKey).idcodeManufId.U(11.W)
+    djtag.pert_number := p(JtagDTMKey).idcodePartNum.U(16.W)
+    djtag.version  := p(JtagDTMKey).idcodeVersion.U(4.W)
 
     djtag.reset    := dut_jtag_reset
     dut_ndreset    := dut.debug.ndreset.get

--- a/src/main/scala/shell/xilinx/ArtyShell.scala
+++ b/src/main/scala/shell/xilinx/ArtyShell.scala
@@ -223,7 +223,7 @@ abstract class ArtyShell(implicit val p: Parameters) extends RawModule {
     djtag.mfr_id   := p(JtagDTMKey).idcodeManufId.U(11.W)
 
     djtag.reset    := dut_jtag_reset
-    dut_ndreset    := dut.debug.ndreset
+    dut_ndreset    := dut.debug.ndreset.get
 
     djtag
   }

--- a/src/main/scala/shell/xilinx/ArtyShell.scala
+++ b/src/main/scala/shell/xilinx/ArtyShell.scala
@@ -184,7 +184,7 @@ abstract class ArtyShell(implicit val p: Parameters) extends RawModule {
 
   def connectDebugJTAG(dut: HasPeripheryDebugModuleImp): SystemJTAGIO = {
 
-    require(dut.debug.ndreset.isDefined, "Connecting JTAG requires that debug module exists")
+    require(dut.debug.isDefined, "Connecting JTAG requires that debug module exists")
     //-------------------------------------------------------------------
     // JTAG Reset
     //-------------------------------------------------------------------
@@ -214,7 +214,7 @@ abstract class ArtyShell(implicit val p: Parameters) extends RawModule {
     // JTAG PINS
     //-------------------------------------------------------------------
 
-    val djtag     = dut.debug.systemjtag.get
+    val djtag     = dut.debug.get.systemjtag.get
 
     djtag.jtag.TCK := dut_jtag_TCK
     djtag.jtag.TMS := dut_jtag_TMS
@@ -226,7 +226,7 @@ abstract class ArtyShell(implicit val p: Parameters) extends RawModule {
     djtag.version  := p(JtagDTMKey).idcodeVersion.U(4.W)
 
     djtag.reset    := dut_jtag_reset
-    dut_ndreset    := dut.debug.ndreset.get
+    dut_ndreset    := dut.debug.get.ndreset
 
     djtag
   }

--- a/src/main/scala/shell/xilinx/VC707Shell.scala
+++ b/src/main/scala/shell/xilinx/VC707Shell.scala
@@ -66,7 +66,7 @@ trait HasDebugJTAG { this: VC707Shell =>
 
   def connectDebugJTAG(dut: HasPeripheryDebugModuleImp, fmcxm105: Boolean = true): SystemJTAGIO = {
   
-    require(dut.debug.ndreset.isDefined, "Connecting JTAG requires that debug module exists")
+    require(dut.debug.isDefined, "Connecting JTAG requires that debug module exists")
     ElaborationArtefacts.add(
     """debugjtag.vivado.tcl""",
     """set vc707debugjtag_vivado_tcl_dir [file dirname [file normalize [info script]]]
@@ -109,7 +109,7 @@ trait HasDebugJTAG { this: VC707Shell =>
       )
     }
    
-    val djtag     = dut.debug.systemjtag.get
+    val djtag     = dut.debug.get.systemjtag.get
 
     djtag.jtag.TCK := jtag_TCK
     djtag.jtag.TMS := jtag_TMS
@@ -121,7 +121,7 @@ trait HasDebugJTAG { this: VC707Shell =>
     djtag.version  := p(JtagDTMKey).idcodeVersion.U(4.W)
 
     djtag.reset    := PowerOnResetFPGAOnly(dut_clock)
-    dut_ndreset    := dut.debug.ndreset.get
+    dut_ndreset    := dut.debug.get.ndreset
     djtag
   }
 }

--- a/src/main/scala/shell/xilinx/VC707Shell.scala
+++ b/src/main/scala/shell/xilinx/VC707Shell.scala
@@ -118,7 +118,7 @@ trait HasDebugJTAG { this: VC707Shell =>
     djtag.mfr_id   := p(JtagDTMKey).idcodeManufId.U(11.W)
 
     djtag.reset    := PowerOnResetFPGAOnly(dut_clock)
-    dut_ndreset    := dut.debug.ndreset
+    dut_ndreset    := dut.debug.ndreset.get
     djtag
   }
 }

--- a/src/main/scala/shell/xilinx/VC707Shell.scala
+++ b/src/main/scala/shell/xilinx/VC707Shell.scala
@@ -66,6 +66,7 @@ trait HasDebugJTAG { this: VC707Shell =>
 
   def connectDebugJTAG(dut: HasPeripheryDebugModuleImp, fmcxm105: Boolean = true): SystemJTAGIO = {
   
+    require(dut.debug.ndreset.isDefined, "Connecting JTAG requires that debug module exists")
     ElaborationArtefacts.add(
     """debugjtag.vivado.tcl""",
     """set vc707debugjtag_vivado_tcl_dir [file dirname [file normalize [info script]]]

--- a/src/main/scala/shell/xilinx/VC707Shell.scala
+++ b/src/main/scala/shell/xilinx/VC707Shell.scala
@@ -117,6 +117,8 @@ trait HasDebugJTAG { this: VC707Shell =>
     jtag_TDO       := djtag.jtag.TDO.data
 
     djtag.mfr_id   := p(JtagDTMKey).idcodeManufId.U(11.W)
+    djtag.part_number := p(JtagDTMKey).idcodePartNum.U(16.W)
+    djtag.version  := p(JtagDTMKey).idcodeVersion.U(4.W)
 
     djtag.reset    := PowerOnResetFPGAOnly(dut_clock)
     dut_ndreset    := dut.debug.ndreset.get

--- a/src/main/scala/shell/xilinx/VCU118Shell.scala
+++ b/src/main/scala/shell/xilinx/VCU118Shell.scala
@@ -206,9 +206,8 @@ abstract class VCU118Shell(implicit val p: Parameters) extends RawModule {
   //---------------------------------------------------------------------
 
   def connectDebugJTAG(dut: HasPeripheryDebugModuleImp): SystemJTAGIO = {
-    val djtag     = dut.debug.systemjtag.get
-
-    require(dut.debug.ndreset.isDefined, "Connecting JTAG requires that debug module exists")
+    require(dut.debug.isDefined, "Connecting JTAG requires that debug module exists")
+    val djtag     = dut.debug.get.systemjtag.get
     djtag.jtag.TCK := jtag_TCK
     djtag.jtag.TMS := jtag_TMS
     djtag.jtag.TDI := jtag_TDI
@@ -219,7 +218,7 @@ abstract class VCU118Shell(implicit val p: Parameters) extends RawModule {
     djtag.version  := p(JtagDTMKey).idcodeVersion.U(4.W)
 
     djtag.reset    := PowerOnResetFPGAOnly(dut_clock)
-    dut_ndreset    := dut.debug.ndreset.get
+    dut_ndreset    := dut.debug.get.ndreset
     djtag
   }
 

--- a/src/main/scala/shell/xilinx/VCU118Shell.scala
+++ b/src/main/scala/shell/xilinx/VCU118Shell.scala
@@ -216,7 +216,7 @@ abstract class VCU118Shell(implicit val p: Parameters) extends RawModule {
     djtag.mfr_id   := p(JtagDTMKey).idcodeManufId.U(11.W)
 
     djtag.reset    := PowerOnResetFPGAOnly(dut_clock)
-    dut_ndreset    := dut.debug.ndreset
+    dut_ndreset    := dut.debug.ndreset.get
     djtag
   }
 

--- a/src/main/scala/shell/xilinx/VCU118Shell.scala
+++ b/src/main/scala/shell/xilinx/VCU118Shell.scala
@@ -208,6 +208,7 @@ abstract class VCU118Shell(implicit val p: Parameters) extends RawModule {
   def connectDebugJTAG(dut: HasPeripheryDebugModuleImp): SystemJTAGIO = {
     val djtag     = dut.debug.systemjtag.get
 
+    require(dut.debug.ndreset.isDefined, "Connecting JTAG requires that debug module exists")
     djtag.jtag.TCK := jtag_TCK
     djtag.jtag.TMS := jtag_TMS
     djtag.jtag.TDI := jtag_TDI

--- a/src/main/scala/shell/xilinx/VCU118Shell.scala
+++ b/src/main/scala/shell/xilinx/VCU118Shell.scala
@@ -215,6 +215,8 @@ abstract class VCU118Shell(implicit val p: Parameters) extends RawModule {
     jtag_TDO       := djtag.jtag.TDO.data
 
     djtag.mfr_id   := p(JtagDTMKey).idcodeManufId.U(11.W)
+    djtag.part_number := p(JtagDTMKey).idcodePartNum.U(16.W)
+    djtag.version  := p(JtagDTMKey).idcodeVersion.U(4.W)
 
     djtag.reset    := PowerOnResetFPGAOnly(dut_clock)
     dut_ndreset    := dut.debug.ndreset.get


### PR DESCRIPTION
Goes with https://github.com/chipsalliance/rocket-chip/pull/2155: The Debug Module and DebugIO are now options.  Also drive the new part_number and version fields of IDCODE.