### PR TITLE
Shell rework

### DIFF
--- a/src/main/scala/shell/DDROverlay.scala
+++ b/src/main/scala/shell/DDROverlay.scala
@@ -7,16 +7,20 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 import sifive.fpgashells.clocks._
 
-case class DDROverlayParams(
+
+case class DDRShellInput()
+case class DDRDesignInput(
   baseAddress: BigInt,
   wrangler: ClockAdapterNode,
   corePLL: PLLNode)(
   implicit val p: Parameters)
+case class DDROverlayOutput(ddr: TLInwardNode)
+trait DDRShellPlacer[Shell] extends ShellPlacer[DDRDesignInput, DDRShellInput, DDROverlayOutput]
 
-case object DDROverlayKey extends Field[Seq[DesignOverlay[DDROverlayParams, TLInwardNode]]](Nil)
+case object DDROverlayKey extends Field[Seq[DesignPlacer[DDRDesignInput, DDRShellInput, DDROverlayOutput]]](Nil)
 
-abstract class DDROverlay[IO <: Data](val params: DDROverlayParams)
-  extends IOOverlay[IO, TLInwardNode]
+abstract class DDRPlacedOverlay[IO <: Data](val name: String, val di: DDRDesignInput, val si: DDRShellInput)
+  extends IOPlacedOverlay[IO, DDRDesignInput, DDRShellInput, DDROverlayOutput]
 {
-  implicit val p = params.p
+  implicit val p = di.p
 }

--- a/src/main/scala/shell/GPIOOverlay.scala
+++ b/src/main/scala/shell/GPIOOverlay.scala
@@ -9,22 +9,28 @@ import freechips.rocketchip.tilelink.TLBusWrapper
 import freechips.rocketchip.interrupts.IntInwardNode
 import chisel3.experimental._
 
-case class GPIOOverlayParams(gpioParam: GPIOParams, controlBus: TLBusWrapper, intNode: IntInwardNode)(implicit val p: Parameters)
-case object GPIOOverlayKey extends Field[Seq[DesignOverlay[GPIOOverlayParams, TLGPIO]]](Nil)
+//Might delete later...
+//Should GPIO be an overlay? Probably not, PinOverlay might take over this use case
+//Plus this should NOT place the controller
+case class GPIOShellInput()
+case class GPIODesignInput(gpioParam: GPIOParams, controlBus: TLBusWrapper, intNode: IntInwardNode)(implicit val p: Parameters)
+case class GPIOOverlayOutput(gpio: TLGPIO)
+case object GPIOOverlayKey extends Field[Seq[DesignPlacer[GPIODesignInput, GPIOShellInput, GPIOOverlayOutput]]](Nil)
+trait GPIOShellPlacer[Shell] extends ShellPlacer[GPIODesignInput, GPIOShellInput, GPIOOverlayOutput]
 
 class ShellGPIOPortIO(width: Int = 4) extends Bundle {
   val gpio = Vec(width, Analog(1.W))
 }
 
-abstract class GPIOOverlay(
-  val params: GPIOOverlayParams)
-    extends IOOverlay[ShellGPIOPortIO, TLGPIO]
+abstract class GPIOPlacedOverlay(
+  val name: String, val di: GPIODesignInput, si: GPIOShellInput)
+    extends IOPlacedOverlay[ShellGPIOPortIO, GPIODesignInput, GPIOShellInput, GPIOOverlayOutput]
 {
-  implicit val p = params.p
+  implicit val p = di.p
 
-  def ioFactory = new ShellGPIOPortIO(params.gpioParam.width)
-  val tlgpio = GPIO.attach(GPIOAttachParams(params.gpioParam, params.controlBus, params.intNode))
+  def ioFactory = new ShellGPIOPortIO(di.gpioParam.width)
+  val tlgpio = GPIO.attach(GPIOAttachParams(di.gpioParam, di.controlBus, di.intNode))
 
   val tlgpioSink = shell { tlgpio.ioNode.makeSink }
-  val designOutput = tlgpio
+  def overlayOutput = GPIOOverlayOutput(gpio = tlgpio)
 }

--- a/src/main/scala/shell/GPIOOverlay.scala
+++ b/src/main/scala/shell/GPIOOverlay.scala
@@ -12,17 +12,17 @@ import chisel3.experimental._
 case class GPIOOverlayParams(gpioParam: GPIOParams, controlBus: TLBusWrapper, intNode: IntInwardNode)(implicit val p: Parameters)
 case object GPIOOverlayKey extends Field[Seq[DesignOverlay[GPIOOverlayParams, TLGPIO]]](Nil)
 
-class FPGAGPIOPortIO(width: Int = 4) extends Bundle {
+class ShellGPIOPortIO(width: Int = 4) extends Bundle {
   val gpio = Vec(width, Analog(1.W))
 }
 
 abstract class GPIOOverlay(
   val params: GPIOOverlayParams)
-    extends IOOverlay[FPGAGPIOPortIO, TLGPIO]
+    extends IOOverlay[ShellGPIOPortIO, TLGPIO]
 {
   implicit val p = params.p
 
-  def ioFactory = new FPGAGPIOPortIO(params.gpioParam.width)
+  def ioFactory = new ShellGPIOPortIO(params.gpioParam.width)
   val tlgpio = GPIO.attach(GPIOAttachParams(params.gpioParam, params.controlBus, params.intNode))
 
   val tlgpioSink = shell { tlgpio.ioNode.makeSink }

--- a/src/main/scala/shell/GPIOOverlay.scala
+++ b/src/main/scala/shell/GPIOOverlay.scala
@@ -27,11 +27,4 @@ abstract class GPIOOverlay(
 
   val tlgpioSink = shell { tlgpio.ioNode.makeSink }
   val designOutput = tlgpio
-
-  shell { InModuleBody {
-      tlgpioSink.bundle.pins.zipWithIndex.foreach{ case (tlpin, idx) => {
-        UIntToAnalog(tlpin.o.oval, io.gpio(idx), tlpin.o.oe)
-        tlpin.i.ival := AnalogToUInt(io.gpio(idx))
-      } }
-  } }
 }

--- a/src/main/scala/shell/GPIOPMODOverlay.scala
+++ b/src/main/scala/shell/GPIOPMODOverlay.scala
@@ -9,8 +9,11 @@ import freechips.rocketchip.tilelink.TLBusWrapper
 import freechips.rocketchip.interrupts.IntInwardNode
 import chisel3.experimental._
 
-case class GPIOPMODOverlayParams()(implicit val p: Parameters)
-case object GPIOPMODOverlayKey extends Field[Seq[DesignOverlay[GPIOPMODOverlayParams, ModuleValue[GPIOPMODPortIO]]]](Nil)
+case class GPIOPMODShellInput()
+case class GPIOPMODDesignInput()(implicit val p: Parameters)
+case class GPIOPMODOverlayOutput(pmod: ModuleValue[GPIOPMODPortIO])
+case object GPIOPMODOverlayKey extends Field[Seq[DesignPlacer[GPIOPMODDesignInput, GPIOPMODShellInput, GPIOPMODOverlayOutput]]](Nil)
+trait GPIOPMODShellPlacer[Shell] extends ShellPlacer[GPIOPMODDesignInput, GPIOPMODShellInput, GPIOPMODOverlayOutput]
 
 class GPIOPMODPortIO extends Bundle {
   val gpio_pmod_0 = Analog(1.W)
@@ -23,41 +26,20 @@ class GPIOPMODPortIO extends Bundle {
   val gpio_pmod_7 = Analog(1.W)
 }
 
-abstract class GPIOPMODOverlay(
-  val params: GPIOPMODOverlayParams)
-    extends IOOverlay[GPIOPMODPortIO, ModuleValue[GPIOPMODPortIO]]
+abstract class GPIOPMODPlacedOverlay(
+  val name: String, val di: GPIOPMODDesignInput, val si: GPIOPMODShellInput)
+    extends IOPlacedOverlay[GPIOPMODPortIO, GPIOPMODDesignInput, GPIOPMODShellInput, GPIOPMODOverlayOutput]
 {
-  implicit val p = params.p
+  implicit val p = di.p
 
   def ioFactory = new GPIOPMODPortIO
 
   val pmodgpioSource = BundleBridgeSource(() => new GPIOPMODPortIO)
   val pmodgpioSink = shell { pmodgpioSource.makeSink }
 
-  val designOutput = InModuleBody { pmodgpioSource.bundle }
+  def overlayOutput = GPIOPMODOverlayOutput(pmod = InModuleBody { pmodgpioSource.bundle } )
 
   shell { InModuleBody {
     io <> pmodgpioSink.bundle
   }}
-/*
-  shell { InModuleBody {
-    UIntToAnalog(tlgpioSink.bundle.pins(0).o.oval, io.gpio_pmod_0, tlgpioSink.bundle.pins(0).o.oe)
-    UIntToAnalog(tlgpioSink.bundle.pins(1).o.oval, io.gpio_pmod_1, tlgpioSink.bundle.pins(1).o.oe)
-    UIntToAnalog(tlgpioSink.bundle.pins(2).o.oval, io.gpio_pmod_2, tlgpioSink.bundle.pins(2).o.oe)
-    UIntToAnalog(tlgpioSink.bundle.pins(3).o.oval, io.gpio_pmod_3, tlgpioSink.bundle.pins(3).o.oe)
-    UIntToAnalog(tlgpioSink.bundle.pins(4).o.oval, io.gpio_pmod_4, tlgpioSink.bundle.pins(4).o.oe)
-    UIntToAnalog(tlgpioSink.bundle.pins(5).o.oval, io.gpio_pmod_5, tlgpioSink.bundle.pins(5).o.oe)
-    UIntToAnalog(tlgpioSink.bundle.pins(6).o.oval, io.gpio_pmod_6, tlgpioSink.bundle.pins(6).o.oe)
-    UIntToAnalog(tlgpioSink.bundle.pins(7).o.oval, io.gpio_pmod_7, tlgpioSink.bundle.pins(7).o.oe)
-
-    tlgpioSink.bundle.pins(0).i.ival := AnalogToUInt(io.gpio_pmod_0)
-    tlgpioSink.bundle.pins(1).i.ival := AnalogToUInt(io.gpio_pmod_1)
-    tlgpioSink.bundle.pins(2).i.ival := AnalogToUInt(io.gpio_pmod_2)
-    tlgpioSink.bundle.pins(3).i.ival := AnalogToUInt(io.gpio_pmod_3)
-    tlgpioSink.bundle.pins(4).i.ival := AnalogToUInt(io.gpio_pmod_4)
-    tlgpioSink.bundle.pins(5).i.ival := AnalogToUInt(io.gpio_pmod_5)
-    tlgpioSink.bundle.pins(6).i.ival := AnalogToUInt(io.gpio_pmod_6)
-    tlgpioSink.bundle.pins(7).i.ival := AnalogToUInt(io.gpio_pmod_7)
-  } }
-*/
 }

--- a/src/main/scala/shell/I2COverlay.scala
+++ b/src/main/scala/shell/I2COverlay.scala
@@ -30,12 +30,4 @@ abstract class I2COverlay(
   val tli2cSink = shell { tli2c.ioNode.makeSink }
 
   val designOutput = tli2c
-
-  shell { InModuleBody {
-    UIntToAnalog(tli2cSink.bundle.scl.out, io.scl, tli2cSink.bundle.scl.oe)
-    UIntToAnalog(tli2cSink.bundle.sda.out, io.sda, tli2cSink.bundle.sda.oe)
-
-    tli2cSink.bundle.scl.in := AnalogToUInt(io.scl)
-    tli2cSink.bundle.sda.in := AnalogToUInt(io.sda)
-  } }
 }

--- a/src/main/scala/shell/IOShell.scala
+++ b/src/main/scala/shell/IOShell.scala
@@ -136,7 +136,8 @@ class SDC(val name: String)
 }
 
 // An IOOverlay is an Overlay with a public shell-level IO
-trait IOOverlay[IO <: Data, DesignOutput] extends Overlay[DesignOutput]
+
+trait IOPlacedOverlay[IO <: Data, DesignInput, ShellInput, OverlayOutput] extends PlacedOverlay[DesignInput, ShellInput, OverlayOutput]
 {
   def ioFactory: IO
   def shell: IOShell

--- a/src/main/scala/shell/JTAGDebugOverlay.scala
+++ b/src/main/scala/shell/JTAGDebugOverlay.scala
@@ -2,38 +2,36 @@
 package sifive.fpgashells.shell
 
 import chisel3._
+import chisel3.experimental._
 import freechips.rocketchip.config._
 import freechips.rocketchip.util._
 import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.jtag._
 import freechips.rocketchip.devices.debug._
 import freechips.rocketchip.subsystem.{BaseSubsystem, PeripheryBus, PeripheryBusKey}
 import sifive.fpgashells.ip.xilinx._
 
 case class JTAGDebugOverlayParams()(implicit val p: Parameters)
-case object JTAGDebugOverlayKey extends Field[Seq[DesignOverlay[JTAGDebugOverlayParams, ModuleValue[FPGAJTAGIO]]]](Nil)
+case object JTAGDebugOverlayKey extends Field[Seq[DesignOverlay[JTAGDebugOverlayParams, ModuleValue[JTAGIO]]]](Nil)
 
-class FPGAJTAGIO extends Bundle {
+class ShellJTAGIO extends Bundle {
   // JTAG
-  val jtag_TCK = Input(Clock())
-  val jtag_TMS = Input(Bool())
-  val jtag_TDI = Input(Bool())
-  val jtag_TDO = Output(Bool())
+  val jtag_TCK = Analog(1.W)
+  val jtag_TMS = Analog(1.W)
+  val jtag_TDI = Analog(1.W)
+  val jtag_TDO = Analog(1.W)
 }
 
 abstract class JTAGDebugOverlay(
   val params: JTAGDebugOverlayParams)
-    extends IOOverlay[FPGAJTAGIO, ModuleValue[FPGAJTAGIO]]
+    extends IOOverlay[ShellJTAGIO, ModuleValue[JTAGIO]]
 {
   implicit val p = params.p
 
-  def ioFactory = new FPGAJTAGIO
+  def ioFactory = new ShellJTAGIO
 
-  val jtagDebugSource = BundleBridgeSource(() => new FPGAJTAGIO)
+  val jtagDebugSource = BundleBridgeSource(() => new JTAGIO())
   val jtagDebugSink = shell { jtagDebugSource.makeSink }
 
   val designOutput = InModuleBody { jtagDebugSource.bundle}
-
-  shell { InModuleBody {
-    io <> jtagDebugSink.bundle
-  } }
 }

--- a/src/main/scala/shell/JTAGDebugOverlay.scala
+++ b/src/main/scala/shell/JTAGDebugOverlay.scala
@@ -43,6 +43,6 @@ abstract class JTAGDebugPlacedOverlay(
 
   val jtagDebugSource = BundleBridgeSource(() => new FlippedJTAGIO())
   val jtagDebugSink = shell { jtagDebugSource.makeSink }
-
-  def overlayOutput = JTAGDebugOverlayOutput(jtag = InModuleBody { jtagDebugSource.bundle} )
+  val jtout = InModuleBody { jtagDebugSource.bundle}
+  def overlayOutput = JTAGDebugOverlayOutput(jtag = jtout)
 }

--- a/src/main/scala/shell/LEDOverlay.scala
+++ b/src/main/scala/shell/LEDOverlay.scala
@@ -5,19 +5,26 @@ import chisel3._
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 
-case class LEDOverlayParams()(implicit val p: Parameters)
-case object LEDOverlayKey extends Field[Seq[DesignOverlay[LEDOverlayParams, ModuleValue[UInt]]]](Nil)
+case class LEDShellInput(
+  color: String = "",
+  header: String = "",
+  rgb: Bool = false.B,
+  number: Int = 0)
 
-abstract class LEDOverlay(
-  val params: LEDOverlayParams)
-    extends IOOverlay[UInt, ModuleValue[UInt]]
+case class LEDDesignInput()(implicit val p: Parameters)
+case class LEDOverlayOutput(led: ModuleValue[Bool])
+case object LEDOverlayKey extends Field[Seq[DesignPlacer[LEDDesignInput, LEDShellInput, LEDOverlayOutput]]](Nil)
+trait LEDShellPlacer[Shell] extends ShellPlacer[LEDDesignInput, LEDShellInput, LEDOverlayOutput]
+
+abstract class LEDPlacedOverlay(
+  val name: String, val di: LEDDesignInput, si: LEDShellInput)
+    extends IOPlacedOverlay[Bool, LEDDesignInput, LEDShellInput, LEDOverlayOutput]
 {
-  implicit val p = params.p
+  implicit val p = di.p
 
-  def width: Int
-  def ioFactory = Output(UInt(width.W))
+  def ioFactory = Output(Bool())
 
-  val ledSource = BundleBridgeSource(() => UInt(width.W))
+  val ledSource = BundleBridgeSource(() => Bool())
   val ledSink = shell { ledSource.makeSink() }
-  val designOutput = InModuleBody { ledSource.out(0)._1 }
+  def overlayOutput = LEDOverlayOutput(InModuleBody { ledSource.out(0)._1 })
 }

--- a/src/main/scala/shell/LEDOverlay.scala
+++ b/src/main/scala/shell/LEDOverlay.scala
@@ -8,7 +8,7 @@ import freechips.rocketchip.diplomacy._
 case class LEDShellInput(
   color: String = "",
   header: String = "",
-  rgb: Bool = false.B,
+  rgb: Boolean = false,
   number: Int = 0)
 
 case class LEDDesignInput()(implicit val p: Parameters)

--- a/src/main/scala/shell/PCIeOverlay.scala
+++ b/src/main/scala/shell/PCIeOverlay.scala
@@ -8,17 +8,24 @@ import freechips.rocketchip.tilelink._
 import freechips.rocketchip.interrupts._
 import sifive.fpgashells.clocks._
 
-case class PCIeOverlayParams(
+case class PCIeShellInput()
+case class PCIeDesignInput(
   wrangler: ClockAdapterNode,
   bars: Seq[AddressSet] = Seq(AddressSet(0x40000000L, 0x1FFFFFFFL)),
   ecam: BigInt = 0x2000000000L,
   corePLL: PLLNode)(
   implicit val p: Parameters)
 
-case object PCIeOverlayKey extends Field[Seq[DesignOverlay[PCIeOverlayParams, (TLNode, IntOutwardNode)]]](Nil)
+case class PCIeOverlayOutput(
+  pcieNode: TLNode,
+  intNode: IntOutwardNode)
+trait PCIeShellPlacer[Shell] extends ShellPlacer[PCIeDesignInput, PCIeShellInput, PCIeOverlayOutput]
 
-abstract class PCIeOverlay[IO <: Data](val params: PCIeOverlayParams)
-  extends IOOverlay[IO, (TLNode, IntOutwardNode)]
+case object PCIeOverlayKey extends Field[Seq[DesignPlacer[PCIeDesignInput, PCIeShellInput, PCIeOverlayOutput]]](Nil)
+
+abstract class PCIePlacedOverlay[IO <: Data](
+  val name: String, val di: PCIeDesignInput, val si: PCIeShellInput)
+    extends IOPlacedOverlay[IO, PCIeDesignInput, PCIeShellInput, PCIeOverlayOutput]
 {
-  implicit val p = params.p
+  implicit val p = di.p
 }

--- a/src/main/scala/shell/PWMOverlay.scala
+++ b/src/main/scala/shell/PWMOverlay.scala
@@ -13,30 +13,20 @@ import freechips.rocketchip.interrupts.IntInwardNode
 case class PWMOverlayParams(pwmParams: PWMParams, controlBus: TLBusWrapper, intNode: IntInwardNode)(implicit val p: Parameters)
 case object PWMOverlayKey extends Field[Seq[DesignOverlay[PWMOverlayParams, TLPWM]]](Nil)
 
-class FPGAPWMPortIO extends Bundle {
-  val pwm_gpio_0 = Output(Bool())
-  val pwm_gpio_1 = Output(Bool())
-  val pwm_gpio_2 = Output(Bool())
-  val pwm_gpio_3 = Output(Bool())
+class ShellPWMPortIO extends Bundle {
+  val pwm_gpio = Vec(4, Analog(1.W))
 }
 
 abstract class PWMOverlay(
   val params: PWMOverlayParams)
-    extends IOOverlay[FPGAPWMPortIO, TLPWM]
+    extends IOOverlay[ShellPWMPortIO, TLPWM]
 {
   implicit val p = params.p
 
-  def ioFactory = new FPGAPWMPortIO
+  def ioFactory = new ShellPWMPortIO
 
   val tlpwm = PWM.attach(PWMAttachParams(params.pwmParams, params.controlBus, params.intNode))
   val tlpwmSink = shell { tlpwm.ioNode.makeSink }
 
   val designOutput = tlpwm
-
-  shell { InModuleBody {
-    io.pwm_gpio_0 := tlpwmSink.bundle.gpio(0)
-    io.pwm_gpio_1 := tlpwmSink.bundle.gpio(1)
-    io.pwm_gpio_2 := tlpwmSink.bundle.gpio(2)
-    io.pwm_gpio_3 := tlpwmSink.bundle.gpio(3)
-  } }
 }

--- a/src/main/scala/shell/PinOverlay.scala
+++ b/src/main/scala/shell/PinOverlay.scala
@@ -1,0 +1,35 @@
+// See LICENSE for license details.
+package sifive.fpgashells.shell
+
+import chisel3._
+import freechips.rocketchip.config._
+import freechips.rocketchip.diplomacy._
+import sifive.blocks.devices.gpio._
+import freechips.rocketchip.tilelink.TLBusWrapper
+import freechips.rocketchip.interrupts.IntInwardNode
+import chisel3.experimental._
+
+case class PinOverlayParams()(implicit val p: Parameters)
+case object PinOverlayKey extends Field[Seq[DesignOverlay[PinOverlayParams, ModuleValue[PinPortIO]]]](Nil)
+
+class PinPortIO extends Bundle {
+  val pins = Vec(8, Analog(1.W))
+}
+
+abstract class PinOverlay(
+  val params: PinOverlayParams)
+    extends IOOverlay[PinPortIO, ModuleValue[PinPortIO]]
+{
+  implicit val p = params.p
+
+  def ioFactory = new PinPortIO
+
+  val pinSource = BundleBridgeSource(() => new PinPortIO)
+  val pinSink = shell { pinSource.makeSink }
+
+  val designOutput = InModuleBody { pinSource.bundle }
+
+  shell { InModuleBody {
+    io <> pinSink.bundle
+  }}
+}

--- a/src/main/scala/shell/SPIFlashOverlay.scala
+++ b/src/main/scala/shell/SPIFlashOverlay.scala
@@ -13,40 +13,21 @@ case class SPIFlashOverlayParams(spiFlashParam: SPIFlashParams, controlBus: TLBu
 case object SPIFlashOverlayKey extends Field[Seq[DesignOverlay[SPIFlashOverlayParams, TLSPIFlash]]](Nil)
 
 
-class FPGASPIFlashPortIO extends Bundle {
-  val qspi_sck  = Output(Bool())
-  val qspi_cs   = Output(Bool())
-  val qspi_dq_0 = Analog(1.W)
-  val qspi_dq_1 = Analog(1.W)
-  val qspi_dq_2 = Analog(1.W)
-  val qspi_dq_3 = Analog(1.W)
+class ShellSPIFlashPortIO extends Bundle {
+  val qspi_sck = Analog(1.W)
+  val qspi_cs  = Analog(1.W)
+  val qspi_dq  = Vec(4, Analog(1.W))
 }
 
 abstract class SPIFlashOverlay(
   val params: SPIFlashOverlayParams)
-    extends IOOverlay[FPGASPIFlashPortIO, TLSPIFlash]
+    extends IOOverlay[ShellSPIFlashPortIO, TLSPIFlash]
 {
   implicit val p = params.p
 
-  def ioFactory = new FPGASPIFlashPortIO
+  def ioFactory = new ShellSPIFlashPortIO
   val tlqspi = SPI.attachFlash(SPIFlashAttachParams(params.spiFlashParam, params.controlBus, params.memBus, params.intNode))
 
   val tlqspiSink = shell { tlqspi.ioNode.makeSink }
   val designOutput = tlqspi
-
-  shell { InModuleBody {
-    io.qspi_sck := tlqspiSink.bundle.sck
-    io.qspi_cs  := tlqspiSink.bundle.cs(0)
-
-    UIntToAnalog(tlqspiSink.bundle.dq(0).o, io.qspi_dq_0, tlqspiSink.bundle.dq(0).oe)
-    UIntToAnalog(tlqspiSink.bundle.dq(1).o, io.qspi_dq_1, tlqspiSink.bundle.dq(1).oe)
-    UIntToAnalog(tlqspiSink.bundle.dq(2).o, io.qspi_dq_2, tlqspiSink.bundle.dq(2).oe)
-    UIntToAnalog(tlqspiSink.bundle.dq(3).o, io.qspi_dq_3, tlqspiSink.bundle.dq(3).oe)
-
-    tlqspiSink.bundle.dq(0).i := AnalogToUInt(io.qspi_dq_0)
-    tlqspiSink.bundle.dq(1).i := AnalogToUInt(io.qspi_dq_1)
-    tlqspiSink.bundle.dq(2).i := AnalogToUInt(io.qspi_dq_2)
-    tlqspiSink.bundle.dq(3).i := AnalogToUInt(io.qspi_dq_3)
-
-  } }
 }

--- a/src/main/scala/shell/Shell.scala
+++ b/src/main/scala/shell/Shell.scala
@@ -13,21 +13,6 @@ import firrtl.annotations._
 import freechips.rocketchip.util.DontTouch
 case object DesignKey extends Field[Parameters => LazyModule]
 
-trait MarkDUT extends DontTouch {
-  self: RawModule =>
-  /** Marks this Module as the DUT
-    *
-    * @note This also marks all ports of the Module as don't touch
-    * @note This method can only be called after the Module has been fully constructed
-    *   (after Module(...))
-    */
-  def markDUT(): this.type = {
-    self.dontTouchPorts()
-    chisel3.experimental.annotate(new ChiselAnnotation { def toFirrtl = MarkDUTAnnotation(self.toNamed) })
-    self
-  }
-}
-
 // Overlays are declared by the Shell and placed somewhere by the Design
 // ... they inject diplomatic code both where they were placed and in the shell
 // ... they are instantiated with DesignInput and return DesignOutput
@@ -79,39 +64,4 @@ abstract class Shell()(implicit p: Parameters) extends LazyModule with LazyScope
 
   // feel free to override this if necessary
   lazy val module = new LazyRawModuleImp(this)
-}
-
-case class MarkDUTAnnotation(target: ModuleName) extends SingleTargetAnnotation[ModuleName] {
-  def duplicate(n: ModuleName): MarkDUTAnnotation = MarkDUTAnnotation(n)
-}
-
-/** Contains helper methods for finding things relative to the DUT while running other transforms */
-object MarkDUTAnnotation {
-  /** Find names of all [[DefModule]]s in the DUT
-    * Throws exception if no MarkDUTAnnotation found
-    * @return (Name of DUT Top, names of other DefModules in the DUT)
-    */
-  def getDUTModules(state: CircuitState): (String, Set[String]) =
-    getDUTModules(state, new InstanceGraph(state.circuit))
-  def getDUTModules(state: CircuitState, igraph: => InstanceGraph): (String, Set[String]) =
-    getDUTModulesOpt(state, igraph).getOrElse(
-      throw new Exception("Attemping to find all Modules in DUT but no MarkDUTAnnotation found!")
-    )
-
-  /** Find names of all [[DefModule]]s in the DUT if annotation found, None otherwise
-    * @return Option(Name of DUT Top, names of other DefModules in the DUT)
-    */
-  def getDUTModulesOpt(state: CircuitState): Option[(String, Set[String])] =
-    getDUTModulesOpt(state, new InstanceGraph(state.circuit))
-  def getDUTModulesOpt(state: CircuitState, igraph: => InstanceGraph): Option[(String, Set[String])] =
-    state.annotations.collect { case MarkDUTAnnotation(ModuleName(dutTop, _)) => dutTop } match {
-      case Seq() => None
-      case Seq(dutTop) =>
-        val mgraph = igraph.graph.transformNodes(_.module)
-        require(mgraph.contains(dutTop),
-          s"MarkDUTAnnotation found but $dutTop does not exist in circuit!")
-        Some((dutTop, mgraph.reachableFrom(dutTop).toSet))
-      case duts =>
-        throw new Exception(s"Error! More than one DUT specified: " + duts.mkString(", "))
-  }
 }

--- a/src/main/scala/shell/SwitchOverlay.scala
+++ b/src/main/scala/shell/SwitchOverlay.scala
@@ -5,19 +5,22 @@ import chisel3._
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 
-case class SwitchOverlayParams()(implicit val p: Parameters)
-case object SwitchOverlayKey extends Field[Seq[DesignOverlay[SwitchOverlayParams, ModuleValue[UInt]]]](Nil)
+case class SwitchShellInput(number: Int = 0)
+case class SwitchDesignInput()(implicit val p: Parameters)
+case class SwitchOverlayOutput(sw: ModuleValue[Bool])
+case object SwitchOverlayKey extends Field[Seq[DesignPlacer[SwitchDesignInput, SwitchShellInput, SwitchOverlayOutput]]](Nil)
+trait SwitchShellPlacer[Shell] extends ShellPlacer[SwitchDesignInput, SwitchShellInput, SwitchOverlayOutput]
 
-abstract class SwitchOverlay(
-  val params: SwitchOverlayParams)
-    extends IOOverlay[UInt, ModuleValue[UInt]]
+abstract class SwitchPlacedOverlay(
+  val name: String, val di: SwitchDesignInput, val si: SwitchShellInput)
+    extends IOPlacedOverlay[Bool, SwitchDesignInput, SwitchShellInput, SwitchOverlayOutput]
 {
-  implicit val p = params.p
+  implicit val p = di.p
 
   def width: Int
-  def ioFactory = Input(UInt(width.W))
+  def ioFactory = Input(Bool())
 
-  val switchSource = shell { BundleBridgeSource(() => UInt(width.W)) }
+  val switchSource = shell { BundleBridgeSource(() => Bool()) }
   val switchSink = switchSource.makeSink()
-  val designOutput = InModuleBody { switchSink.bundle }
+  def overlayOutput = SwitchOverlayOutput(sw = InModuleBody { switchSink.bundle } )
 }

--- a/src/main/scala/shell/SwitchOverlay.scala
+++ b/src/main/scala/shell/SwitchOverlay.scala
@@ -17,7 +17,6 @@ abstract class SwitchPlacedOverlay(
 {
   implicit val p = di.p
 
-  def width: Int
   def ioFactory = Input(Bool())
 
   val switchSource = shell { BundleBridgeSource(() => Bool()) }

--- a/src/main/scala/shell/TracePMODOverlay.scala
+++ b/src/main/scala/shell/TracePMODOverlay.scala
@@ -9,18 +9,21 @@ import freechips.rocketchip.tilelink.TLBusWrapper
 import freechips.rocketchip.interrupts.IntInwardNode
 import chisel3.experimental._
 
-case class TracePMODOverlayParams()(implicit val p: Parameters)
-case object TracePMODOverlayKey extends Field[Seq[DesignOverlay[TracePMODOverlayParams, ModuleValue[UInt]]]](Nil)
+case class TracePMODShellInput()
+case class TracePMODDesignInput()(implicit val p: Parameters)
+case class TracePMODOverlayOutput(trace: ModuleValue[UInt])
+case object TracePMODOverlayKey extends Field[Seq[DesignPlacer[TracePMODDesignInput, TracePMODShellInput, TracePMODOverlayOutput]]](Nil)
+trait TracePMODShellPlacer[Shell] extends ShellPlacer[TracePMODDesignInput, TracePMODShellInput, TracePMODOverlayOutput]
 
-abstract class TracePMODOverlay(
-  val params: TracePMODOverlayParams)
-    extends IOOverlay[UInt, ModuleValue[UInt]]
+abstract class TracePMODPlacedOverlay(
+  val name: String, val di: TracePMODDesignInput, val si: TracePMODShellInput)
+    extends IOPlacedOverlay[UInt, TracePMODDesignInput, TracePMODShellInput, TracePMODOverlayOutput]
 {
-  implicit val p = params.p
+  implicit val p = di.p
 
   def ioFactory = Output(UInt(8.W))
 
   val pmodTraceSource = BundleBridgeSource(() => UInt(8.W))
   val pmodTraceSink = shell { pmodTraceSource.makeSink }
-  val designOutput = InModuleBody { pmodTraceSource.out(0)._1 }
+  def overlayOutput = TracePMODOverlayOutput(trace = InModuleBody { pmodTraceSource.out(0)._1 } )
 }

--- a/src/main/scala/shell/TracePMODOverlay.scala
+++ b/src/main/scala/shell/TracePMODOverlay.scala
@@ -25,5 +25,6 @@ abstract class TracePMODPlacedOverlay(
 
   val pmodTraceSource = BundleBridgeSource(() => UInt(8.W))
   val pmodTraceSink = shell { pmodTraceSource.makeSink }
-  def overlayOutput = TracePMODOverlayOutput(trace = InModuleBody { pmodTraceSource.out(0)._1 } )
+  val traceout = InModuleBody { pmodTraceSource.out(0)._1 }
+  def overlayOutput = TracePMODOverlayOutput(trace = traceout )
 }

--- a/src/main/scala/shell/UARTOverlay.scala
+++ b/src/main/scala/shell/UARTOverlay.scala
@@ -2,6 +2,7 @@
 package sifive.fpgashells.shell
 
 import chisel3._
+import chisel3.experimental._
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 import sifive.blocks.devices.uart._
@@ -15,20 +16,22 @@ case object UARTOverlayKey extends Field[Seq[DesignOverlay[UARTOverlayParams, TL
 
 // Tack on cts, rts signals available on some FPGAs. They are currently unused
 // by our designs.
-class FPGAUARTPortIO(flowControl: Boolean) extends UARTPortIO {
-  val rtsn = if (flowControl) Some(Output(Bool())) else None
-  val ctsn = if (flowControl) Some(Input(Bool())) else None
+class ShellUARTPortIO(flowControl: Boolean) extends Bundle {
+  val txd = Analog(1.W)
+  val rxd = Analog(1.W)
+  val rtsn = if (flowControl) Some(Analog(1.W)) else None
+  val ctsn = if (flowControl) Some(Analog(1.W)) else None
 }
 
 //class UARTReplacementBundle extends Bundle with HasUARTTopBundleContents
 
 abstract class UARTOverlay(
   val params: UARTOverlayParams, flowControl: Boolean)
-    extends IOOverlay[FPGAUARTPortIO, TLUART]
+    extends IOOverlay[ShellUARTPortIO, TLUART]
 {
   implicit val p = params.p
 
-  def ioFactory = new FPGAUARTPortIO(flowControl)
+  def ioFactory = new ShellUARTPortIO(flowControl)
 
   val tluart = UART.attach(UARTAttachParams(params.uartParams, params.divInit, params.controlBus, params.intNode))
   val tluartSink = tluart.ioNode.makeSink
@@ -36,16 +39,4 @@ abstract class UARTOverlay(
   val uartSink = shell { uartSource.makeSink }
 
   val designOutput = tluart
-
-  InModuleBody {
-    val (io, _) = uartSource.out(0)
-    val tluartport = tluartSink.bundle
-    io <> tluartport
-    tluartport.rxd := RegNext(RegNext(io.rxd))
-  }
-
-  shell { InModuleBody {
-    io.txd := uartSink.bundle.txd
-    uartSink.bundle.rxd := io.rxd
-  } }
 }

--- a/src/main/scala/shell/microsemi/ChipLinkOverlay.scala
+++ b/src/main/scala/shell/microsemi/ChipLinkOverlay.scala
@@ -7,8 +7,8 @@ import freechips.rocketchip.util._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.microsemi._
 
- abstract class ChipLinkPolarFireOverlay(params: ChipLinkOverlayParams)
-  extends ChipLinkOverlay(params, rxPhase=180, txPhase=270)
+ abstract class ChipLinkPolarFirePlacedOverlay(name: String, di: ChipLinkDesignInput, si: ChipLinkShellInput)
+  extends ChipLinkPlacedOverlay(name, di, si, rxPhase=180, txPhase=270)
 {
   def shell: PolarFireShell
 

--- a/src/main/scala/shell/microsemi/ClockOverlay.scala
+++ b/src/main/scala/shell/microsemi/ClockOverlay.scala
@@ -6,8 +6,8 @@ import freechips.rocketchip.diplomacy._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.microsemi._
 
- abstract class ClockInputMicrosemiOverlay(params: ClockInputOverlayParams)
-  extends SingleEndedClockInputOverlay(params)
+ abstract class ClockInputMicrosemiPlacedOverlay(name: String, di: ClockInputDesignInput, si: ClockInputShellInput)
+  extends SingleEndedClockInputPlacedOverlay(name, di, si)
 {
   def shell: MicrosemiShell
 

--- a/src/main/scala/shell/microsemi/LEDOverlay.scala
+++ b/src/main/scala/shell/microsemi/LEDOverlay.scala
@@ -6,8 +6,8 @@ import freechips.rocketchip.diplomacy._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.microsemi._
 
- abstract class LEDMicrosemiOverlay(params: LEDOverlayParams, pins: Seq[String] = Nil)
-  extends LEDOverlay(params)
+ abstract class LEDMicrosemiPlacedOverlay(name: String, di: LEDDesignInput, si: LEDShellInput, pins: Seq[String] = Nil)
+  extends LEDPlacedOverlay(name, di, si)
 {
   def shell: MicrosemiShell
   val width = pins.size

--- a/src/main/scala/shell/microsemi/VeraShell.scala
+++ b/src/main/scala/shell/microsemi/VeraShell.scala
@@ -23,8 +23,8 @@ import sifive.fpgashells.ip.microsemi.polarfireclockdivider._
 import sifive.fpgashells.ip.microsemi.polarfireglitchlessmux._
 import sifive.fpgashells.ip.microsemi.polarfirereset._
 
-class SysClockVeraOverlay(val shell: VeraShell, val name: String, params: ClockInputOverlayParams)
-  extends ClockInputMicrosemiOverlay(params)
+class SysClockVeraPlacedOverlay(val shell: VeraShell, name: String, val designInput: ClockInputDesignInput, val shellInput: ClockInputShellInput)
+  extends ClockInputMicrosemiPlacedOverlay(name, designInput, shellInput)
 {
   val node = shell { ClockSourceNode(name, freqMHz = 50, jitterPS = 50)(ValName(name)) }
 
@@ -34,20 +34,20 @@ class SysClockVeraOverlay(val shell: VeraShell, val name: String, params: ClockI
     shell.io_pdc.addPin(io:Clock, "AG4")
   } }
 }
-object SysClockVeraOverlay {
-  implicit object SysClockVeraMetadata extends HasMetadata[SysClockVeraOverlay] {
-    def metadata = OverlayMetadata()
-} }
+class SysClockVeraShellPlacer(val shell: VeraShell, val shellInput: ClockInputShellInput)(implicit val valName: ValName)
+  extends ClockInputShellPlacer[VeraShell] {
+  def place(designInput: ClockInputDesignInput) = new SysClockVeraPlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class LEDVeraOverlay(val shell: VeraShell, val name: String, params: LEDOverlayParams)
-  extends LEDMicrosemiOverlay(params, Seq("AK17", "AN17", "AM17", "AL18"))
-object LEDVeraOverlay {
-  implicit object LEDVeraMetadata extends HasMetadata[LEDVeraOverlay] {
-    def metadata = OverlayMetadata()
-} }
+class LEDVeraPlacedOverlay(val shell: VeraShell, name: String, val designInput: LEDDesignInput, val shellInput: LEDShellInput)
+  extends LEDMicrosemiPlacedOverlay(name, designInput, shellInput, Seq("AK17", "AN17", "AM17", "AL18"))
+class LEDVeraShellPlacer(val shell: VeraShell, val shellInput: LEDShellInput)(implicit val valName: ValName)
+  extends LEDShellPlacer[VeraShell] {
+  def place(designInput: LEDDesignInput) = new LEDVeraPlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class ChipLinkVeraOverlay(val shell: VeraShell, val name: String, params: ChipLinkOverlayParams)
-  extends ChipLinkPolarFireOverlay(params)
+class ChipLinkVeraPlacedOverlay(val shell: VeraShell, name: String, val designInput: ChipLinkDesignInput, val shellInput: ChipLinkShellInput)
+  extends ChipLinkPolarFirePlacedOverlay(name, designInput, shellInput)
 {
   val ereset_n = shell { InModuleBody {
     val ereset_n = IO(Input(Bool()))
@@ -78,13 +78,13 @@ class ChipLinkVeraOverlay(val shell: VeraShell, val name: String, params: ChipLi
     rx.reset := shell.pllReset
   } }
 }
-object ChipLinkVeraOverlay {
-  implicit object ChipLinkVeraMetadata extends HasMetadata[ChipLinkVeraOverlay] {
-    def metadata = OverlayMetadata()
-} }
+class ChipLinkVeraShellPlacer(val shell: VeraShell, val shellInput: ChipLinkShellInput)(implicit val valName: ValName)
+  extends ChipLinkShellPlacer[VeraShell] {
+  def place(designInput: ChipLinkDesignInput) = new ChipLinkVeraPlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class PCIeVeraOverlay(val shell: VeraShell, val name: String, params: PCIeOverlayParams)
-  extends PCIeOverlay[PolarFireEvalKitPCIeX4Pads](params)
+class PCIeVeraPlacedOverlay(val shell: VeraShell, name: String, val designInput: PCIeDesignInput, val shellInput: PCIeShellInput)
+  extends PCIePlacedOverlay[PolarFireEvalKitPCIeX4Pads](name, designInput, shellInput)
 {
   val sdcClockName = "axiClock"
   val pcie = LazyModule(new PolarFireEvalKitPCIeX4)
@@ -92,7 +92,7 @@ class PCIeVeraOverlay(val shell: VeraShell, val name: String, params: PCIeOverla
   val topIONode = shell { ioNode.makeSink() }
   val pcieClk_125 = shell { ClockSinkNode(freqMHz = 125)}
   val pcieGroup = shell { ClockGroup()}
-  pcieClk_125 := params.wrangler := pcieGroup := params.corePLL
+  pcieClk_125 := designInput.wrangler := pcieGroup := designInput.corePLL
 
   val slaveSide = TLIdentityNode()
   pcie.crossTLIn(pcie.slave) := slaveSide
@@ -100,13 +100,13 @@ class PCIeVeraOverlay(val shell: VeraShell, val name: String, params: PCIeOverla
   val node = NodeHandle(slaveSide, pcie.crossTLOut(pcie.master))
   val intnode = pcie.crossIntOut(pcie.intnode)
 
-  def designOutput = (node, intnode)
+  def overlayOutput = PCIeOverlayOutput(node, intnode)
   def ioFactory = new PolarFireEvalKitPCIeX4Pads
 
   InModuleBody { ioNode.bundle <> pcie.module.io }
 
   shell { InModuleBody {
-    val (sys, _) = shell.sys_clock.get.node.out(0)
+    val (sys, _) = shell.sys_clock.get.get.overlayOutput.node.out(0)
     val (pcieClk, _) = pcieClk_125.in(0)
     val port = topIONode.bundle.port
     val coreClock = shell.pllFactory.plls.getWrappedValue(1)._1.getClocks(0)
@@ -220,31 +220,32 @@ class PCIeVeraOverlay(val shell: VeraShell, val name: String, params: PCIeOverla
 
   shell.sdc.addGroup(clocks = Seq("osc_rc160mhz"))
 }
-object PCIeVeraOverlay {
-  implicit object PCIeVeraMetadata extends HasMetadata[PCIeVeraOverlay] {
-    def metadata = OverlayMetadata()
-} }
+class PCIeVeraShellPlacer(val shell: VeraShell, val shellInput: PCIeShellInput)(implicit val valName: ValName)
+  extends PCIeShellPlacer[VeraShell] {
+  def place(designInput: PCIeDesignInput) = new PCIeVeraPlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
 class VeraShell()(implicit p: Parameters) extends PolarFireShell
 {
   // PLL reset causes
   val pllReset = InModuleBody { Wire(Bool()) }
 
-  val sys_clock = Overlay(ClockInputOverlayKey)(new SysClockVeraOverlay(_, _, _))
-//  val led       = Overlay(LEDOverlayKey)       (new LEDVeraOverlay     (_, _, _))
-  val chiplink  = Overlay(ChipLinkOverlayKey)  (new ChipLinkVeraOverlay(_, _, _))
-  val pcie      = Overlay(PCIeOverlayKey)      (new PCIeVeraOverlay    (_, _, _))
+  val sys_clock = Overlay(ClockInputOverlayKey, new SysClockVeraShellPlacer(this, ClockInputShellInput()))
+  val led       = Overlay(LEDOverlayKey, new LEDVeraShellPlacer(this, LEDShellInput()))
+  val chiplink  = Overlay(ChipLinkOverlayKey, new ChipLinkVeraShellPlacer(this, ChipLinkShellInput()))
+  val pcie      = Overlay(PCIeOverlayKey, new PCIeVeraShellPlacer(this, PCIeShellInput()))
 
   val topDesign = LazyModule(p(DesignKey)(designParameters))
 
   override lazy val module = new LazyRawModuleImp(this) {
     val pf_user_reset_n = IO(Input(Bool()))
     io_pdc.addPin(pf_user_reset_n, "AK18")
-
+    val ereset: Bool = chiplink.get() match {
+      case Some(x: ChipLinkVeraPlacedOverlay) => !x.ereset_n
+      case _ => false.B
+    }
     pllReset :=
       !pf_user_reset_n ||
-      !initMonitor.io.DEVICE_INIT_DONE ||
-      chiplink.map(!_.ereset_n).getOrElse(false.B)
-
+      !initMonitor.io.DEVICE_INIT_DONE || ereset
   }
 }

--- a/src/main/scala/shell/microsemi/VeraShell.scala
+++ b/src/main/scala/shell/microsemi/VeraShell.scala
@@ -34,9 +34,17 @@ class SysClockVeraOverlay(val shell: VeraShell, val name: String, params: ClockI
     shell.io_pdc.addPin(io:Clock, "AG4")
   } }
 }
+object SysClockVeraOverlay {
+  implicit object SysClockVeraMetadata extends HasMetadata[SysClockVeraOverlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class LEDVeraOverlay(val shell: VeraShell, val name: String, params: LEDOverlayParams)
   extends LEDMicrosemiOverlay(params, Seq("AK17", "AN17", "AM17", "AL18"))
+object LEDVeraOverlay {
+  implicit object LEDVeraMetadata extends HasMetadata[LEDVeraOverlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class ChipLinkVeraOverlay(val shell: VeraShell, val name: String, params: ChipLinkOverlayParams)
   extends ChipLinkPolarFireOverlay(params)
@@ -70,6 +78,10 @@ class ChipLinkVeraOverlay(val shell: VeraShell, val name: String, params: ChipLi
     rx.reset := shell.pllReset
   } }
 }
+object ChipLinkVeraOverlay {
+  implicit object ChipLinkVeraMetadata extends HasMetadata[ChipLinkVeraOverlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class PCIeVeraOverlay(val shell: VeraShell, val name: String, params: PCIeOverlayParams)
   extends PCIeOverlay[PolarFireEvalKitPCIeX4Pads](params)
@@ -208,6 +220,10 @@ class PCIeVeraOverlay(val shell: VeraShell, val name: String, params: PCIeOverla
 
   shell.sdc.addGroup(clocks = Seq("osc_rc160mhz"))
 }
+object PCIeVeraOverlay {
+  implicit object PCIeVeraMetadata extends HasMetadata[PCIeVeraOverlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class VeraShell()(implicit p: Parameters) extends PolarFireShell
 {

--- a/src/main/scala/shell/xilinx/Arty100TShell.scala
+++ b/src/main/scala/shell/xilinx/Arty100TShell.scala
@@ -12,8 +12,8 @@ import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.xilinx._
 import sifive.fpgashells.devices.xilinx.xilinxarty100tmig._
 
-class SysClockArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: ClockInputOverlayParams)
-  extends SingleEndedClockInputXilinxOverlay(params)
+class SysClockArtyPlacedOverlay(val shell: Arty100TShellBasicOverlays, name: String, val designInput: ClockInputDesignInput, val shellInput: ClockInputShellInput)
+  extends SingleEndedClockInputXilinxPlacedOverlay(name, designInput, shellInput)
 {
   val node = shell { ClockSourceNode(name, freqMHz = 100, jitterPS = 50) }
 
@@ -23,14 +23,14 @@ class SysClockArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: Strin
     shell.xdc.addIOStandard(clk, "LVCMOS33")
   } }
 }
-object SysClockArtyOverlay {
-  implicit object SysClockArtyMetadata extends HasMetadata[SysClockArtyOverlay] {
-    def metadata = OverlayMetadata()
-} }
+class SysClockArtyShellPlacer(val shell: Arty100TShellBasicOverlays, val shellInput: ClockInputShellInput)(implicit val valName: ValName)
+  extends ClockInputShellPlacer[Arty100TShellBasicOverlays] {
+  def place(designInput: ClockInputDesignInput) = new SysClockArtyPlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
 //PMOD JA used for SDIO
-class SDIOArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: SDIOOverlayParams)
-  extends SDIOXilinxOverlay(params)
+class SDIOArtyPlacedOverlay(val shell: Arty100TShellBasicOverlays, name: String, val designInput: SDIODesignInput, val shellInput: SDIOShellInput)
+  extends SDIOXilinxPlacedOverlay(name, designInput, shellInput)
 {
   shell { InModuleBody {
     val packagePinsWithPackageIOs = Seq(("D12", IOPin(io.sdio_clk)),
@@ -50,13 +50,13 @@ class SDIOArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, p
     } }
   } }
 }
-object SDIOArtyOverlay {
-  implicit object SDIOArtyMetadata extends HasMetadata[SDIOArtyOverlay] {
-    def metadata = OverlayMetadata()
-} }
+class SDIOArtyShellPlacer(val shell: Arty100TShellBasicOverlays, val shellInput: SDIOShellInput)(implicit val valName: ValName)
+  extends SDIOShellPlacer[Arty100TShellBasicOverlays] {
+  def place(designInput: SDIODesignInput) = new SDIOArtyPlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class SPIFlashArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: SPIFlashOverlayParams)
-  extends SPIFlashXilinxOverlay(params)
+class SPIFlashArtyPlacedOverlay(val shell: Arty100TShellBasicOverlays, name: String, val designInput: SPIFlashDesignInput, val shellInput: SPIFlashShellInput)
+  extends SPIFlashXilinxPlacedOverlay(name, designInput, shellInput)
 {
 
   shell { InModuleBody {
@@ -76,20 +76,20 @@ class SPIFlashArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: Strin
     } }
   } }
 }
-object SPIFlashArtyOverlay {
-  implicit object SPIFlashArtyMetadata extends HasMetadata[SPIFlashArtyOverlay] {
-    def metadata = OverlayMetadata()
-} }
+class SPIFlashArtyShellPlacer(val shell: Arty100TShellBasicOverlays, val shellInput: SPIFlashShellInput)(implicit val valName: ValName)
+  extends SPIFlashShellPlacer[Arty100TShellBasicOverlays] {
+  def place(designInput: SPIFlashDesignInput) = new SPIFlashArtyPlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class TracePMODArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: TracePMODOverlayParams)
-  extends TracePMODXilinxOverlay(params, packagePins = Seq("U12", "V12", "V10", "V11", "U14", "V14", "T13", "U13"))
-object TracePMODArtyOverlay {
-  implicit object TracePMODArtyMetadata extends HasMetadata[TracePMODArtyOverlay] {
-    def metadata = OverlayMetadata()
-} }
+class TracePMODArtyPlacedOverlay(val shell: Arty100TShellBasicOverlays, name: String, val designInput: TracePMODDesignInput, val shellInput: TracePMODShellInput)
+  extends TracePMODXilinxPlacedOverlay(name, designInput, shellInput, packagePins = Seq("U12", "V12", "V10", "V11", "U14", "V14", "T13", "U13"))
+class TracePMODArtyShellPlacer(val shell: Arty100TShellBasicOverlays, val shellInput: TracePMODShellInput)(implicit val valName: ValName)
+  extends TracePMODShellPlacer[Arty100TShellBasicOverlays] {
+  def place(designInput: TracePMODDesignInput) = new TracePMODArtyPlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class GPIOPMODArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: GPIOPMODOverlayParams)
-  extends GPIOPMODXilinxOverlay(params)
+class GPIOPMODArtyPlacedOverlay(val shell: Arty100TShellBasicOverlays, name: String, val designInput: GPIOPMODDesignInput, val shellInput: GPIOPMODShellInput)
+  extends GPIOPMODXilinxPlacedOverlay(name, designInput, shellInput)
 {
   shell { InModuleBody {
     val packagePinsWithPackageIOs = Seq(("E15", IOPin(io.gpio_pmod_0)), //These are PMOD B
@@ -107,13 +107,13 @@ class GPIOPMODArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: Strin
     } }
   } }
 }
-object GPIOPMODArtyOverlay {
-  implicit object GPIOPMODArtyMetadata extends HasMetadata[GPIOPMODArtyOverlay] {
-    def metadata = OverlayMetadata()
-} }
+class GPIOPMODArtyShellPlacer(val shell: Arty100TShellBasicOverlays, val shellInput: GPIOPMODShellInput)(implicit val valName: ValName)
+  extends GPIOPMODShellPlacer[Arty100TShellBasicOverlays] {
+  def place(designInput: GPIOPMODDesignInput) = new GPIOPMODArtyPlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class UARTArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: UARTOverlayParams)
-  extends UARTXilinxOverlay(params, false)
+class UARTArtyPlacedOverlay(val shell: Arty100TShellBasicOverlays, name: String, val designInput: UARTDesignInput, val shellInput: UARTShellInput)
+  extends UARTXilinxPlacedOverlay(name, designInput, shellInput, false)
 {
   shell { InModuleBody {
     val packagePinsWithPackageIOs = Seq(("A9", IOPin(io.rxd)),
@@ -126,38 +126,38 @@ class UARTArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, p
     } }
   } }
 }
-object UARTArtyOverlay {
-  implicit object UARTArtyMetadata extends HasMetadata[UARTArtyOverlay] {
-    def metadata = OverlayMetadata()
-} }
+class UARTArtyShellPlacer(val shell: Arty100TShellBasicOverlays, val shellInput: UARTShellInput)(implicit val valName: ValName)
+  extends UARTShellPlacer[Arty100TShellBasicOverlays] {
+  def place(designInput: UARTDesignInput) = new UARTArtyPlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
 //LEDS - 4 normal leds, r0, g0, b0, r1, g1, b1 ...
-class LEDArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: LEDOverlayParams)
-  extends LEDXilinxOverlay(params, packagePins = Seq("H5", "J5", "T9", "T10", "G6", "F6", "E1", "G3", "J4", "G4", "J3", "J2", "H4", "K1", "H6", "K2"))
-object LEDArtyOverlay {
-  implicit object LEDArtyMetadata extends HasMetadata[LEDArtyOverlay] {
-    def metadata = OverlayMetadata()
-} }
+class LEDArtyPlacedOverlay(val shell: Arty100TShellBasicOverlays, name: String, val designInput: LEDDesignInput, val shellInput: LEDShellInput)
+  extends LEDXilinxPlacedOverlay(name, designInput, shellInput, packagePins = Seq("H5", "J5", "T9", "T10", "G6", "F6", "E1", "G3", "J4", "G4", "J3", "J2", "H4", "K1", "H6", "K2"))
+class LEDArtyShellPlacer(val shell: Arty100TShellBasicOverlays, val shellInput: LEDShellInput)(implicit val valName: ValName)
+  extends LEDShellPlacer[Arty100TShellBasicOverlays] {
+  def place(designInput: LEDDesignInput) = new LEDArtyPlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
 //SWs
-class SwitchArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: SwitchOverlayParams)
-  extends SwitchXilinxOverlay(params, packagePins = Seq("A8", "C11", "C10", "A10"))
-object SwitchArtyOverlay {
-  implicit object SwitchArtyMetadata extends HasMetadata[SwitchArtyOverlay] {
-    def metadata = OverlayMetadata()
-} }
+class SwitchArtyPlacedOverlay(val shell: Arty100TShellBasicOverlays, name: String, val designInput: SwitchDesignInput, val shellInput: SwitchShellInput)
+  extends SwitchXilinxPlacedOverlay(name, designInput, shellInput, packagePins = Seq("A8", "C11", "C10", "A10"))
+class SwitchArtyShellPlacer(val shell: Arty100TShellBasicOverlays, val shellInput: SwitchShellInput)(implicit val valName: ValName)
+  extends SwitchShellPlacer[Arty100TShellBasicOverlays] {
+  def place(designInput: SwitchDesignInput) = new SwitchArtyPlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
 //Buttons
-class ButtonArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: ButtonOverlayParams)
-  extends ButtonXilinxOverlay(params, packagePins = Seq("D9", "C9", "B9", "B8"))
-object ButtonArtyOverlay {
-  implicit object ButtonArtyMetadata extends HasMetadata[ButtonArtyOverlay] {
-    def metadata = OverlayMetadata()
-} }
+class ButtonArtyPlacedOverlay(val shell: Arty100TShellBasicOverlays, name: String, val designInput: ButtonDesignInput, val shellInput: ButtonShellInput)
+  extends ButtonXilinxPlacedOverlay(name, designInput, shellInput, packagePins = Seq("D9", "C9", "B9", "B8"))
+class ButtonArtyShellPlacer(val shell: Arty100TShellBasicOverlays, val shellInput: ButtonShellInput)(implicit val valName: ValName)
+  extends ButtonShellPlacer[Arty100TShellBasicOverlays] {
+  def place(designInput: ButtonDesignInput) = new ButtonArtyPlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
 // PMOD JD used for JTAG
-class JTAGDebugArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: JTAGDebugOverlayParams)
-  extends JTAGDebugXilinxOverlay(params)
+class JTAGDebugArtyPlacedOverlay(val shell: Arty100TShellBasicOverlays, name: String, val designInput: JTAGDebugDesignInput, val shellInput: JTAGDebugShellInput)
+  extends JTAGDebugXilinxPlacedOverlay(name, designInput, shellInput)
 {
   shell { InModuleBody {
     shell.sdc.addClock("JTCK", IOPin(io.jtag_TCK), 10)
@@ -175,14 +175,14 @@ class JTAGDebugArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: Stri
     } }
   } }
 }
-object JTAGDebugArtyOverlay {
-  implicit object JTAGDebugArtyMetadata extends HasMetadata[JTAGDebugArtyOverlay] {
-    def metadata = OverlayMetadata()
-} }
+class JTAGDebugArtyShellPlacer(val shell: Arty100TShellBasicOverlays, val shellInput: JTAGDebugShellInput)(implicit val valName: ValName)
+  extends JTAGDebugShellPlacer[Arty100TShellBasicOverlays] {
+  def place(designInput: JTAGDebugDesignInput) = new JTAGDebugArtyPlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
 //cjtag
-class cJTAGDebugArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: cJTAGDebugOverlayParams)
-  extends cJTAGDebugXilinxOverlay(params)
+class cJTAGDebugArtyPlacedOverlay(val shell: Arty100TShellBasicOverlays, name: String, val designInput: cJTAGDebugDesignInput, val shellInput: cJTAGDebugShellInput)
+  extends cJTAGDebugXilinxPlacedOverlay(name, designInput, shellInput)
 {
   shell { InModuleBody {
     shell.sdc.addClock("JTCKC", IOPin(io.cjtag_TCKC), 10)
@@ -199,40 +199,40 @@ class cJTAGDebugArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: Str
     } }
   } }
 }
-object cJTAGDebugArtyOverlay {
-  implicit object cJTAGDebugArtyMetadata extends HasMetadata[cJTAGDebugArtyOverlay] {
-    def metadata = OverlayMetadata()
-} }
+class cJTAGDebugArtyShellPlacer(val shell: Arty100TShellBasicOverlays, val shellInput: cJTAGDebugShellInput)(implicit val valName: ValName)
+  extends cJTAGDebugShellPlacer[Arty100TShellBasicOverlays] {
+  def place(designInput: cJTAGDebugDesignInput) = new cJTAGDebugArtyPlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
 case object ArtyDDRSize extends Field[BigInt](0x10000000L * 1) // 256 MB
-class DDRArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: DDROverlayParams)
-  extends DDROverlay[XilinxArty100TMIGPads](params)
+class DDRArtyPlacedOverlay(val shell: Arty100TShellBasicOverlays, name: String, val designInput: DDRDesignInput, val shellInput: DDRShellInput)
+  extends DDRPlacedOverlay[XilinxArty100TMIGPads](name, designInput, shellInput)
 {
   val size = p(ArtyDDRSize)
 
   val ddrClk1 = shell { ClockSinkNode(freqMHz = 166.666)}
   val ddrClk2 = shell { ClockSinkNode(freqMHz = 200)}
   val ddrGroup = shell { ClockGroup() }
-  ddrClk1 := params.wrangler := ddrGroup := params.corePLL
-  ddrClk2 := params.wrangler := ddrGroup
+  ddrClk1 := di.wrangler := ddrGroup := di.corePLL
+  ddrClk2 := di.wrangler := ddrGroup
   
   val sdcClockName = "userclk1"
-  val migParams = XilinxArty100TMIGParams(address = AddressSet.misaligned(params.baseAddress, size))
+  val migParams = XilinxArty100TMIGParams(address = AddressSet.misaligned(di.baseAddress, size))
   val mig = LazyModule(new XilinxArty100TMIG(migParams))
   val ioNode = BundleBridgeSource(() => mig.module.io.cloneType)
   val topIONode = shell { ioNode.makeSink() }
   val ddrUI     = shell { ClockSourceNode(sdcClockName, freqMHz = 100) }
   val areset    = shell { ClockSinkNode(Seq(ClockSinkParameters())) }
-  areset := params.wrangler := ddrUI
+  areset := di.wrangler := ddrUI
 
-  def designOutput = mig.node
+  def overlayOutput = DDROverlayOutput(ddr = mig.node)
   def ioFactory = new XilinxArty100TMIGPads(size)
 
   InModuleBody { ioNode.bundle <> mig.module.io }
 
   shell { InModuleBody {
-    require (shell.sys_clock.isDefined, "Use of DDRArtyOverlay depends on SysClockArtyOverlay")
-    val (sys, _) = shell.sys_clock.get.node.out(0)
+    require (shell.sys_clock.get.isDefined, "Use of DDRArtyPlacedOverlay depends on SysClockArtyPlacedOverlay")
+    val (sys, _) = shell.sys_clock.get.get.overlayOutput.node.out(0)
     val (ui, _) = ddrUI.out(0)
     val (dclk1, _) = ddrClk1.in(0)
     val (dclk2, _) = ddrClk2.in(0)
@@ -250,23 +250,23 @@ class DDRArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, pa
 
   shell.sdc.addGroup(clocks = Seq("clk_pll_i", "userClock1"))
 }
-object DDRArtyOverlay {
-  implicit object DDRArtyMetadata extends HasMetadata[DDRArtyOverlay] {
-    def metadata = OverlayMetadata()
-} }
+class DDRArtyShellPlacer(val shell: Arty100TShellBasicOverlays, val shellInput: DDRShellInput)(implicit val valName: ValName)
+  extends DDRShellPlacer[Arty100TShellBasicOverlays] {
+  def place(designInput: DDRDesignInput) = new DDRArtyPlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
 abstract class Arty100TShellBasicOverlays()(implicit p: Parameters) extends Series7Shell {
   // Order matters; ddr depends on sys_clock
-  val sys_clock = Overlay(ClockInputOverlayKey)(new SysClockArtyOverlay   (_, _, _))
-  val led       = Overlay(LEDOverlayKey)       (new LEDArtyOverlay        (_, _, _))
-  val switch    = Overlay(SwitchOverlayKey)    (new SwitchArtyOverlay     (_, _, _))
-  val button    = Overlay(ButtonOverlayKey)    (new ButtonArtyOverlay     (_, _, _))
-  val ddr       = Overlay(DDROverlayKey)       (new DDRArtyOverlay        (_, _, _))
-  val uart      = Overlay(UARTOverlayKey)      (new UARTArtyOverlay       (_, _, _))
-  val sdio      = Overlay(SDIOOverlayKey)      (new SDIOArtyOverlay       (_, _, _))
-  val jtag      = Overlay(JTAGDebugOverlayKey) (new JTAGDebugArtyOverlay  (_, _, _))
-  val cjtag     = Overlay(cJTAGDebugOverlayKey) (new cJTAGDebugArtyOverlay  (_, _, _))
-  val spi_flash = Overlay(SPIFlashOverlayKey)  (new SPIFlashArtyOverlay   (_, _, _))
+  val sys_clock = Overlay(ClockInputOverlayKey, new SysClockArtyShellPlacer(this, ClockInputShellInput()))
+  val led       = Overlay(LEDOverlayKey, new LEDArtyShellPlacer(this, LEDShellInput()))
+  val switch    = Overlay(SwitchOverlayKey, new SwitchArtyShellPlacer(this, SwitchShellInput()))
+  val button    = Overlay(ButtonOverlayKey, new ButtonArtyShellPlacer(this, ButtonShellInput()))
+  val ddr       = Overlay(DDROverlayKey, new DDRArtyShellPlacer(this, DDRShellInput()))
+  val uart      = Overlay(UARTOverlayKey, new UARTArtyShellPlacer(this, UARTShellInput()))
+  val sdio      = Overlay(SDIOOverlayKey, new SDIOArtyShellPlacer(this, SDIOShellInput()))
+  val jtag      = Overlay(JTAGDebugOverlayKey, new JTAGDebugArtyShellPlacer(this, JTAGDebugShellInput()))
+  val cjtag     = Overlay(cJTAGDebugOverlayKey, new cJTAGDebugArtyShellPlacer(this, cJTAGDebugShellInput()))
+  val spi_flash = Overlay(SPIFlashOverlayKey, new SPIFlashArtyShellPlacer(this, SPIFlashShellInput()))
 }
 
 class Arty100TShell()(implicit p: Parameters) extends Arty100TShellBasicOverlays
@@ -277,7 +277,7 @@ class Arty100TShell()(implicit p: Parameters) extends Arty100TShellBasicOverlays
   val topDesign = LazyModule(p(DesignKey)(designParameters))
 
   // Place the sys_clock at the Shell if the user didn't ask for it
-  p(ClockInputOverlayKey).foreach(_(ClockInputOverlayParams()))
+  p(ClockInputOverlayKey).foreach(_.place(ClockInputDesignInput()))
 
   override lazy val module = new LazyRawModuleImp(this) {
     val reset = IO(Input(Bool()))
@@ -285,8 +285,10 @@ class Arty100TShell()(implicit p: Parameters) extends Arty100TShellBasicOverlays
 
     val reset_ibuf = Module(new IBUF)
     reset_ibuf.io.I := reset
-
-    val powerOnReset = PowerOnResetFPGAOnly(sys_clock.get.clock)
+    val sysclk: Clock = sys_clock.get() match {
+      case Some(x: SysClockArtyPlacedOverlay) => x.clock
+    }
+    val powerOnReset = PowerOnResetFPGAOnly(sysclk)
     sdc.addAsyncPath(Seq(powerOnReset))
 
     pllReset :=
@@ -300,13 +302,13 @@ class Arty100TShellGPIOPMOD()(implicit p: Parameters) extends Arty100TShellBasic
   // PLL reset causes
   val pllReset = InModuleBody { Wire(Bool()) }
 
-  val gpio_pmod = Overlay(GPIOPMODOverlayKey) (new GPIOPMODArtyOverlay (_,_,_))
-  val trace_pmod = Overlay(TracePMODOverlayKey) (new TracePMODArtyOverlay (_,_,_))
+  val gpio_pmod = Overlay(GPIOPMODOverlayKey, new GPIOPMODArtyShellPlacer(this, GPIOPMODShellInput()))
+  val trace_pmod = Overlay(TracePMODOverlayKey, new TracePMODArtyShellPlacer(this, TracePMODShellInput()))
 
   val topDesign = LazyModule(p(DesignKey)(designParameters))
 
   // Place the sys_clock at the Shell if the user didn't ask for it
-  p(ClockInputOverlayKey).foreach(_(ClockInputOverlayParams()))
+  p(ClockInputOverlayKey).foreach(_.place(ClockInputDesignInput()))
 
   override lazy val module = new LazyRawModuleImp(this) {
     val reset = IO(Input(Bool()))
@@ -314,8 +316,10 @@ class Arty100TShellGPIOPMOD()(implicit p: Parameters) extends Arty100TShellBasic
 
     val reset_ibuf = Module(new IBUF)
     reset_ibuf.io.I := reset
-
-    val powerOnReset = PowerOnResetFPGAOnly(sys_clock.get.clock)
+    val sysclk: Clock = sys_clock.get() match {
+      case Some(x: SysClockArtyPlacedOverlay) => x.clock
+    }
+    val powerOnReset = PowerOnResetFPGAOnly(sysclk)
     sdc.addAsyncPath(Seq(powerOnReset))
 
     pllReset :=

--- a/src/main/scala/shell/xilinx/Arty100TShell.scala
+++ b/src/main/scala/shell/xilinx/Arty100TShell.scala
@@ -23,6 +23,10 @@ class SysClockArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: Strin
     shell.xdc.addIOStandard(clk, "LVCMOS33")
   } }
 }
+object SysClockArtyOverlay {
+  implicit object SysClockArtyMetadata extends HasMetadata[SysClockArtyOverlay] {
+    def metadata = OverlayMetadata()
+} }
 
 //PMOD JA used for SDIO
 class SDIOArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: SDIOOverlayParams)
@@ -46,6 +50,10 @@ class SDIOArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, p
     } }
   } }
 }
+object SDIOArtyOverlay {
+  implicit object SDIOArtyMetadata extends HasMetadata[SDIOArtyOverlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class SPIFlashArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: SPIFlashOverlayParams)
   extends SPIFlashXilinxOverlay(params)
@@ -68,14 +76,21 @@ class SPIFlashArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: Strin
     } }
   } }
 }
+object SPIFlashArtyOverlay {
+  implicit object SPIFlashArtyMetadata extends HasMetadata[SPIFlashArtyOverlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class TracePMODArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: TracePMODOverlayParams)
   extends TracePMODXilinxOverlay(params, packagePins = Seq("U12", "V12", "V10", "V11", "U14", "V14", "T13", "U13"))
+object TracePMODArtyOverlay {
+  implicit object TracePMODArtyMetadata extends HasMetadata[TracePMODArtyOverlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class GPIOPMODArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: GPIOPMODOverlayParams)
   extends GPIOPMODXilinxOverlay(params)
 {
-
   shell { InModuleBody {
     val packagePinsWithPackageIOs = Seq(("E15", IOPin(io.gpio_pmod_0)), //These are PMOD B
       ("E16", IOPin(io.gpio_pmod_1)),
@@ -92,6 +107,10 @@ class GPIOPMODArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: Strin
     } }
   } }
 }
+object GPIOPMODArtyOverlay {
+  implicit object GPIOPMODArtyMetadata extends HasMetadata[GPIOPMODArtyOverlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class UARTArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: UARTOverlayParams)
   extends UARTXilinxOverlay(params, false)
@@ -107,18 +126,34 @@ class UARTArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, p
     } }
   } }
 }
+object UARTArtyOverlay {
+  implicit object UARTArtyMetadata extends HasMetadata[UARTArtyOverlay] {
+    def metadata = OverlayMetadata()
+} }
 
 //LEDS - 4 normal leds, r0, g0, b0, r1, g1, b1 ...
 class LEDArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: LEDOverlayParams)
   extends LEDXilinxOverlay(params, packagePins = Seq("H5", "J5", "T9", "T10", "G6", "F6", "E1", "G3", "J4", "G4", "J3", "J2", "H4", "K1", "H6", "K2"))
+object LEDArtyOverlay {
+  implicit object LEDArtyMetadata extends HasMetadata[LEDArtyOverlay] {
+    def metadata = OverlayMetadata()
+} }
 
 //SWs
 class SwitchArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: SwitchOverlayParams)
   extends SwitchXilinxOverlay(params, packagePins = Seq("A8", "C11", "C10", "A10"))
+object SwitchArtyOverlay {
+  implicit object SwitchArtyMetadata extends HasMetadata[SwitchArtyOverlay] {
+    def metadata = OverlayMetadata()
+} }
 
 //Buttons
 class ButtonArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: ButtonOverlayParams)
   extends ButtonXilinxOverlay(params, packagePins = Seq("D9", "C9", "B9", "B8"))
+object ButtonArtyOverlay {
+  implicit object ButtonArtyMetadata extends HasMetadata[ButtonArtyOverlay] {
+    def metadata = OverlayMetadata()
+} }
 
 // PMOD JD used for JTAG
 class JTAGDebugArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: JTAGDebugOverlayParams)
@@ -140,6 +175,10 @@ class JTAGDebugArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: Stri
     } }
   } }
 }
+object JTAGDebugArtyOverlay {
+  implicit object JTAGDebugArtyMetadata extends HasMetadata[JTAGDebugArtyOverlay] {
+    def metadata = OverlayMetadata()
+} }
 
 //cjtag
 class cJTAGDebugArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: cJTAGDebugOverlayParams)
@@ -160,6 +199,10 @@ class cJTAGDebugArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: Str
     } }
   } }
 }
+object cJTAGDebugArtyOverlay {
+  implicit object cJTAGDebugArtyMetadata extends HasMetadata[cJTAGDebugArtyOverlay] {
+    def metadata = OverlayMetadata()
+} }
 
 case object ArtyDDRSize extends Field[BigInt](0x10000000L * 1) // 256 MB
 class DDRArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, params: DDROverlayParams)
@@ -207,6 +250,10 @@ class DDRArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: String, pa
 
   shell.sdc.addGroup(clocks = Seq("clk_pll_i", "userClock1"))
 }
+object DDRArtyOverlay {
+  implicit object DDRArtyMetadata extends HasMetadata[DDRArtyOverlay] {
+    def metadata = OverlayMetadata()
+} }
 
 abstract class Arty100TShellBasicOverlays()(implicit p: Parameters) extends Series7Shell {
   // Order matters; ddr depends on sys_clock

--- a/src/main/scala/shell/xilinx/Arty100TShell.scala
+++ b/src/main/scala/shell/xilinx/Arty100TShell.scala
@@ -54,10 +54,10 @@ class SPIFlashArtyOverlay(val shell: Arty100TShellBasicOverlays, val name: Strin
   shell { InModuleBody {
     val packagePinsWithPackageIOs = Seq(("L16", IOPin(io.qspi_sck)),
       ("L13", IOPin(io.qspi_cs)),
-      ("K17", IOPin(io.qspi_dq_0)),
-      ("K18", IOPin(io.qspi_dq_1)),
-      ("L14", IOPin(io.qspi_dq_2)),
-      ("M14", IOPin(io.qspi_dq_3)))
+      ("K17", IOPin(io.qspi_dq(0))),
+      ("K18", IOPin(io.qspi_dq(1))),
+      ("L14", IOPin(io.qspi_dq(2))),
+      ("M14", IOPin(io.qspi_dq(3))))
 
     packagePinsWithPackageIOs foreach { case (pin, io) => {
       shell.xdc.addPackagePin(io, pin)

--- a/src/main/scala/shell/xilinx/ButtonOverlay.scala
+++ b/src/main/scala/shell/xilinx/ButtonOverlay.scala
@@ -6,11 +6,10 @@ import freechips.rocketchip.diplomacy._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.xilinx._
 
-abstract class ButtonXilinxPlacedOverlay(name: String, di: ButtonDesignInput, si: ButtonShellInput, boardPins: Seq[String] = Nil, packagePins: Seq[String] = Nil, ioStandard: String = "LVCMOS33")
+abstract class ButtonXilinxPlacedOverlay(name: String, di: ButtonDesignInput, si: ButtonShellInput, boardPin: Option[String] = None, packagePin: Option[String] = None, ioStandard: String = "LVCMOS33")
   extends ButtonPlacedOverlay(name, di, si)
 {
   def shell: XilinxShell
-  val width = boardPins.size + packagePins.size
 
   shell { InModuleBody {
     val but  = Wire(Bool())
@@ -20,13 +19,14 @@ abstract class ButtonXilinxPlacedOverlay(name: String, di: ButtonDesignInput, si
     ibuf.io.I := io
     but := ibuf.io.O
 
-    val cutAt = boardPins.size
+    require((boardPin.isEmpty || packagePin.isEmpty), "can't provide both boardpin and packagepin, this is ambiguous")
+    val cutAt = if(boardPin.isDefined) 1 else 0
     val ios = IOPin.of(io)
-    val boardIOs = ios.take(cutAt)
-    val packageIOs = ios.drop(cutAt)
+    val boardIO = ios.take(cutAt)
+    val packageIO = ios.drop(cutAt)
 
-    (boardPins   zip boardIOs)   foreach { case (pin, io) => shell.xdc.addBoardPin  (io, pin) }
-    (packagePins zip packageIOs) foreach { case (pin, io) =>
+    (boardPin   zip boardIO)   foreach { case (pin, io) => shell.xdc.addBoardPin  (io, pin) }
+    (packagePin zip packageIO) foreach { case (pin, io) =>
       shell.xdc.addPackagePin(io, pin)
       shell.xdc.addIOStandard(io, ioStandard)
     }

--- a/src/main/scala/shell/xilinx/ButtonOverlay.scala
+++ b/src/main/scala/shell/xilinx/ButtonOverlay.scala
@@ -6,21 +6,19 @@ import freechips.rocketchip.diplomacy._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.xilinx._
 
-abstract class ButtonXilinxOverlay(params: ButtonOverlayParams, boardPins: Seq[String] = Nil, packagePins: Seq[String] = Nil, ioStandard: String = "LVCMOS33")
-  extends ButtonOverlay(params)
+abstract class ButtonXilinxPlacedOverlay(name: String, di: ButtonDesignInput, si: ButtonShellInput, boardPins: Seq[String] = Nil, packagePins: Seq[String] = Nil, ioStandard: String = "LVCMOS33")
+  extends ButtonPlacedOverlay(name, di, si)
 {
   def shell: XilinxShell
   val width = boardPins.size + packagePins.size
 
   shell { InModuleBody {
-    val vec = Wire(Vec(width, Bool()))
-    buttonSource.out(0)._1 := vec.asUInt
-    (vec zip io.toBools).zipWithIndex.foreach { case ((o, i), idx) =>
-      val ibuf = Module(new IBUF)
-      ibuf.suggestName(s"button_ibuf_${idx}")
-      ibuf.io.I := i
-      o := ibuf.io.O
-    }
+    val but  = Wire(Bool())
+    buttonSource.out(0)._1 := but
+    val ibuf = Module(new IBUF)
+    ibuf.suggestName(s"button_ibuf_${si.number}")
+    ibuf.io.I := io
+    but := ibuf.io.O
 
     val cutAt = boardPins.size
     val ios = IOPin.of(io)

--- a/src/main/scala/shell/xilinx/ChipLinkOverlay.scala
+++ b/src/main/scala/shell/xilinx/ChipLinkOverlay.scala
@@ -7,8 +7,8 @@ import freechips.rocketchip.util._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.xilinx._
 
-abstract class ChipLinkXilinxOverlay(params: ChipLinkOverlayParams, rxPhase: Double, txPhase: Double, rxMargin: Double, txMargin: Double)
-  extends ChipLinkOverlay(params.copy(params = params.params.copy(fpgaReset = true))(params.p), rxPhase, txPhase)
+abstract class ChipLinkXilinxPlacedOverlay(name: String, di: ChipLinkDesignInput, si: ChipLinkShellInput, rxPhase: Double, txPhase: Double, rxMargin: Double, txMargin: Double)
+  extends ChipLinkPlacedOverlay(name, di.copy(di = di.di.copy(fpgaReset = true))(di.p), si, rxPhase, txPhase)
 {
   def shell: XilinxShell
 

--- a/src/main/scala/shell/xilinx/ClockOverlay.scala
+++ b/src/main/scala/shell/xilinx/ClockOverlay.scala
@@ -6,8 +6,8 @@ import freechips.rocketchip.diplomacy._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.xilinx._
 
-abstract class LVDSClockInputXilinxOverlay(params: ClockInputOverlayParams)
-  extends LVDSClockInputOverlay(params)
+abstract class LVDSClockInputXilinxPlacedOverlay(name: String, di: ClockInputDesignInput, si: ClockInputShellInput)
+  extends LVDSClockInputPlacedOverlay(name, di, si)
 {
   def shell: XilinxShell
 
@@ -24,8 +24,8 @@ abstract class LVDSClockInputXilinxOverlay(params: ClockInputOverlayParams)
 }
 
 
-abstract class SingleEndedClockInputXilinxOverlay(params: ClockInputOverlayParams)
-  extends SingleEndedClockInputOverlay(params)
+abstract class SingleEndedClockInputXilinxPlacedOverlay(name: String, di: ClockInputDesignInput, si: ClockInputShellInput)
+  extends SingleEndedClockInputPlacedOverlay(name, di, si)
 {
   def shell: XilinxShell
 

--- a/src/main/scala/shell/xilinx/GPIOPMODXilinxOverlay.scala
+++ b/src/main/scala/shell/xilinx/GPIOPMODXilinxOverlay.scala
@@ -6,8 +6,8 @@ import freechips.rocketchip.diplomacy._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.xilinx._
 
-abstract class GPIOPMODXilinxOverlay(params: GPIOPMODOverlayParams)
-  extends GPIOPMODOverlay(params)
+abstract class GPIOPMODXilinxPlacedOverlay(name: String, di: GPIOPMODDesignInput, si: GPIOPMODShellInput)
+  extends GPIOPMODPlacedOverlay(name, di, si)
 {
   def shell: XilinxShell
 }

--- a/src/main/scala/shell/xilinx/GPIOXilinxOverlay.scala
+++ b/src/main/scala/shell/xilinx/GPIOXilinxOverlay.scala
@@ -10,4 +10,11 @@ abstract class GPIOXilinxOverlay(params: GPIOOverlayParams)
   extends GPIOOverlay(params)
 {
   def shell: XilinxShell
+
+  shell { InModuleBody {
+      tlgpioSink.bundle.pins.zipWithIndex.foreach{ case (tlpin, idx) => {
+        UIntToAnalog(tlpin.o.oval, io.gpio(idx), tlpin.o.oe)
+        tlpin.i.ival := AnalogToUInt(io.gpio(idx))
+      } }
+  } }
 }

--- a/src/main/scala/shell/xilinx/GPIOXilinxOverlay.scala
+++ b/src/main/scala/shell/xilinx/GPIOXilinxOverlay.scala
@@ -6,8 +6,8 @@ import freechips.rocketchip.diplomacy._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.xilinx._
 
-abstract class GPIOXilinxOverlay(params: GPIOOverlayParams)
-  extends GPIOOverlay(params)
+abstract class GPIOXilinxPlacedOverlay(name: String, di: GPIODesignInput, si: GPIOShellInput)
+  extends GPIOPlacedOverlay(name, di, si)
 {
   def shell: XilinxShell
 

--- a/src/main/scala/shell/xilinx/I2COverlay.scala
+++ b/src/main/scala/shell/xilinx/I2COverlay.scala
@@ -10,4 +10,12 @@ import sifive.fpgashells.ip.xilinx._
   extends I2COverlay(params)
 {
   def shell: XilinxShell
+
+  shell { InModuleBody {
+    UIntToAnalog(tli2cSink.bundle.scl.out, io.scl, tli2cSink.bundle.scl.oe)
+    UIntToAnalog(tli2cSink.bundle.sda.out, io.sda, tli2cSink.bundle.sda.oe)
+
+    tli2cSink.bundle.scl.in := AnalogToUInt(io.scl)
+    tli2cSink.bundle.sda.in := AnalogToUInt(io.sda)
+  } }
 }

--- a/src/main/scala/shell/xilinx/I2COverlay.scala
+++ b/src/main/scala/shell/xilinx/I2COverlay.scala
@@ -6,8 +6,8 @@ import freechips.rocketchip.diplomacy._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.xilinx._
 
- abstract class I2CXilinxOverlay(params: I2COverlayParams)
-  extends I2COverlay(params)
+ abstract class I2CXilinxPlacedOverlay(name: String, di: I2CDesignInput, si: I2CShellInput)
+  extends I2CPlacedOverlay(name, di, si)
 {
   def shell: XilinxShell
 

--- a/src/main/scala/shell/xilinx/JTAGDebugOverlay.scala
+++ b/src/main/scala/shell/xilinx/JTAGDebugOverlay.scala
@@ -12,7 +12,7 @@ abstract class JTAGDebugXilinxOverlay(params: JTAGDebugOverlayParams)
   def shell: XilinxShell
 
   shell { InModuleBody {
-    jtagDebugSink.bundle.TCK := AnalogToUInt(io.jtag_TCK)
+    jtagDebugSink.bundle.TCK := AnalogToUInt(io.jtag_TCK).asBool.asClock
     jtagDebugSink.bundle.TMS := AnalogToUInt(io.jtag_TMS)
     jtagDebugSink.bundle.TDI := AnalogToUInt(io.jtag_TDI)
     UIntToAnalog(jtagDebugSink.bundle.TDO.data,io.jtag_TDO,jtagDebugSink.bundle.TDO.driven)

--- a/src/main/scala/shell/xilinx/JTAGDebugOverlay.scala
+++ b/src/main/scala/shell/xilinx/JTAGDebugOverlay.scala
@@ -10,4 +10,11 @@ abstract class JTAGDebugXilinxOverlay(params: JTAGDebugOverlayParams)
   extends JTAGDebugOverlay(params)
 {
   def shell: XilinxShell
+
+  shell { InModuleBody {
+    jtagDebugSink.bundle.TCK := AnalogToUInt(io.jtag_TCK)
+    jtagDebugSink.bundle.TMS := AnalogToUInt(io.jtag_TMS)
+    jtagDebugSink.bundle.TDI := AnalogToUInt(io.jtag_TDI)
+    UIntToAnalog(jtagDebugSink.bundle.TDO.data,io.jtag_TDO,jtagDebugSink.bundle.TDO.driven)
+  } }
 }

--- a/src/main/scala/shell/xilinx/JTAGDebugOverlay.scala
+++ b/src/main/scala/shell/xilinx/JTAGDebugOverlay.scala
@@ -6,8 +6,8 @@ import freechips.rocketchip.diplomacy._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.xilinx._
 
-abstract class JTAGDebugXilinxOverlay(params: JTAGDebugOverlayParams)
-  extends JTAGDebugOverlay(params)
+abstract class JTAGDebugXilinxPlacedOverlay(name: String, di: JTAGDebugDesignInput, si: JTAGDebugShellInput)
+  extends JTAGDebugPlacedOverlay(name, di, si)
 {
   def shell: XilinxShell
 

--- a/src/main/scala/shell/xilinx/LEDOverlay.scala
+++ b/src/main/scala/shell/xilinx/LEDOverlay.scala
@@ -6,22 +6,22 @@ import freechips.rocketchip.diplomacy._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.xilinx._
 
-abstract class LEDXilinxPlacedOverlay(name: String, di: LEDDesignInput, si: LEDShellInput, boardPins: Seq[String] = Nil, packagePins: Seq[String] = Nil, ioStandard: String = "LVCMOS33")
+abstract class LEDXilinxPlacedOverlay(name: String, di: LEDDesignInput, si: LEDShellInput, boardPin: Option[String] = None, packagePin: Option[String] = None, ioStandard: String = "LVCMOS33")
   extends LEDPlacedOverlay(name, di, si)
 {
   def shell: XilinxShell
-  val width = boardPins.size + packagePins.size
 
   shell { InModuleBody {
     io := ledSink.bundle // could/should put OBUFs here?
 
-    val cutAt = boardPins.size
+    require((boardPin.isEmpty || packagePin.isEmpty), "can't provide both boardpin and packagepin, this is ambiguous")
+    val cutAt = if(boardPin.isDefined) 1 else 0
     val ios = IOPin.of(io)
-    val boardIOs = ios.take(cutAt)
-    val packageIOs = ios.drop(cutAt)
+    val boardIO = ios.take(cutAt)
+    val packageIO = ios.drop(cutAt)
 
-    (boardPins   zip boardIOs)   foreach { case (pin, io) => shell.xdc.addBoardPin  (io, pin) }
-    (packagePins zip packageIOs) foreach { case (pin, io) =>
+    (boardPin   zip boardIO)   foreach { case (pin, io) => shell.xdc.addBoardPin  (io, pin) }
+    (packagePin zip packageIO) foreach { case (pin, io) =>
       shell.xdc.addPackagePin(io, pin)
       shell.xdc.addIOStandard(io, ioStandard)
     }

--- a/src/main/scala/shell/xilinx/LEDOverlay.scala
+++ b/src/main/scala/shell/xilinx/LEDOverlay.scala
@@ -6,8 +6,8 @@ import freechips.rocketchip.diplomacy._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.xilinx._
 
-abstract class LEDXilinxOverlay(params: LEDOverlayParams, boardPins: Seq[String] = Nil, packagePins: Seq[String] = Nil, ioStandard: String = "LVCMOS33")
-  extends LEDOverlay(params)
+abstract class LEDXilinxPlacedOverlay(name: String, di: LEDDesignInput, si: LEDShellInput, boardPins: Seq[String] = Nil, packagePins: Seq[String] = Nil, ioStandard: String = "LVCMOS33")
+  extends LEDPlacedOverlay(name, di, si)
 {
   def shell: XilinxShell
   val width = boardPins.size + packagePins.size
@@ -21,7 +21,7 @@ abstract class LEDXilinxOverlay(params: LEDOverlayParams, boardPins: Seq[String]
     val packageIOs = ios.drop(cutAt)
 
     (boardPins   zip boardIOs)   foreach { case (pin, io) => shell.xdc.addBoardPin  (io, pin) }
-    (packagePins zip packageIOs) foreach { case (pin, io) => 
+    (packagePins zip packageIOs) foreach { case (pin, io) =>
       shell.xdc.addPackagePin(io, pin)
       shell.xdc.addIOStandard(io, ioStandard)
     }

--- a/src/main/scala/shell/xilinx/PWMOverlay.scala
+++ b/src/main/scala/shell/xilinx/PWMOverlay.scala
@@ -6,8 +6,14 @@ import freechips.rocketchip.diplomacy._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.xilinx._
 
- abstract class PWMXilinxOverlay(params: PWMOverlayParams)
+abstract class PWMXilinxOverlay(params: PWMOverlayParams)
   extends PWMOverlay(params)
 {
   def shell: XilinxShell
+
+  shell { InModuleBody {
+    tlpwmSink.bundle.gpio.zip(io.pwm_gpio).foreach { case(design_pwm, io_pwm) =>
+      io_pwm := design_pwm 
+    }
+  } }
 }

--- a/src/main/scala/shell/xilinx/PWMOverlay.scala
+++ b/src/main/scala/shell/xilinx/PWMOverlay.scala
@@ -6,8 +6,8 @@ import freechips.rocketchip.diplomacy._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.xilinx._
 
-abstract class PWMXilinxOverlay(params: PWMOverlayParams)
-  extends PWMOverlay(params)
+abstract class PWMXilinxPlacedOverlay(name: String, di: PWMDesignInput, si: PWMShellInput)
+  extends PWMPlacedOverlay(name, di, si)
 {
   def shell: XilinxShell
 

--- a/src/main/scala/shell/xilinx/PinXilinxOverlay.scala
+++ b/src/main/scala/shell/xilinx/PinXilinxOverlay.scala
@@ -6,8 +6,8 @@ import freechips.rocketchip.diplomacy._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.xilinx._
 
-abstract class PinXilinxOverlay(params: PinOverlayParams)
-  extends PinOverlay(params)
+abstract class PinXilinxPlacedOverlay(name: String, di: PinDesignInput, si: PinShellInput)
+  extends PinPlacedOverlay(name, di, si)
 {
   def shell: XilinxShell
 }

--- a/src/main/scala/shell/xilinx/PinXilinxOverlay.scala
+++ b/src/main/scala/shell/xilinx/PinXilinxOverlay.scala
@@ -1,0 +1,13 @@
+// See LICENSE for license details.
+package sifive.fpgashells.shell.xilinx
+
+import chisel3._
+import freechips.rocketchip.diplomacy._
+import sifive.fpgashells.shell._
+import sifive.fpgashells.ip.xilinx._
+
+abstract class PinXilinxOverlay(params: PinOverlayParams)
+  extends PinOverlay(params)
+{
+  def shell: XilinxShell
+}

--- a/src/main/scala/shell/xilinx/SDIOOverlay.scala
+++ b/src/main/scala/shell/xilinx/SDIOOverlay.scala
@@ -6,8 +6,8 @@ import freechips.rocketchip.diplomacy._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.xilinx._
 
-abstract class SDIOXilinxOverlay(params: SDIOOverlayParams)
-  extends SDIOOverlay(params)
+abstract class SDIOXilinxPlacedOverlay(name: String, di: SDIODesignInput, si: SDIOShellInput)
+  extends SDIOPlacedOverlay(name, di, si)
 {
   def shell: XilinxShell
 }

--- a/src/main/scala/shell/xilinx/SPIFlashXilinxOverlay.scala
+++ b/src/main/scala/shell/xilinx/SPIFlashXilinxOverlay.scala
@@ -6,8 +6,8 @@ import freechips.rocketchip.diplomacy._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.xilinx._
 
-abstract class SPIFlashXilinxOverlay(params: SPIFlashOverlayParams)
-  extends SPIFlashOverlay(params)
+abstract class SPIFlashXilinxPlacedOverlay(name: String, di: SPIFlashDesignInput, si: SPIFlashShellInput)
+  extends SPIFlashPlacedOverlay(name, di, si)
 {
   def shell: XilinxShell
 

--- a/src/main/scala/shell/xilinx/SPIFlashXilinxOverlay.scala
+++ b/src/main/scala/shell/xilinx/SPIFlashXilinxOverlay.scala
@@ -10,4 +10,14 @@ abstract class SPIFlashXilinxOverlay(params: SPIFlashOverlayParams)
   extends SPIFlashOverlay(params)
 {
   def shell: XilinxShell
+
+  shell { InModuleBody {
+    UIntToAnalog(tlqspiSink.bundle.sck  , io.qspi_sck, true.B)
+    UIntToAnalog(tlqspiSink.bundle.cs(0), io.qspi_cs , true.B)
+
+    tlqspiSink.bundle.dq.zip(io.qspi_dq).foreach { case(design_dq, io_dq) => 
+      UIntToAnalog(design_dq.o, io_dq, design_dq.oe)
+      design_dq.i := AnalogToUInt(io_dq)
+    }
+  } }
 }

--- a/src/main/scala/shell/xilinx/SwitchOverlay.scala
+++ b/src/main/scala/shell/xilinx/SwitchOverlay.scala
@@ -6,8 +6,8 @@ import freechips.rocketchip.diplomacy._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.xilinx._
 
-abstract class SwitchXilinxOverlay(params: SwitchOverlayParams, boardPins: Seq[String] = Nil, packagePins: Seq[String] = Nil, ioStandard: String = "LVCMOS33")
-  extends SwitchOverlay(params)
+abstract class SwitchXilinxPlacedOverlay(name: String, di: SwitchDesignInput, si: SwitchShellInput, boardPins: Seq[String] = Nil, packagePins: Seq[String] = Nil, ioStandard: String = "LVCMOS33")
+  extends SwitchPlacedOverlay(name, di, si)
 {
   def shell: XilinxShell
   val width = boardPins.size + packagePins.size

--- a/src/main/scala/shell/xilinx/TracePMODOverlay.scala
+++ b/src/main/scala/shell/xilinx/TracePMODOverlay.scala
@@ -6,8 +6,8 @@ import freechips.rocketchip.diplomacy._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.xilinx._
 
-abstract class TracePMODXilinxOverlay(params: TracePMODOverlayParams, boardPins: Seq[String] = Nil, packagePins: Seq[String] = Nil, ioStandard: String = "LVCMOS33")
-  extends TracePMODOverlay(params)
+abstract class TracePMODXilinxPlacedOverlay(name: String, di: TracePMODDesignInput, si: TracePMODShellInput, boardPins: Seq[String] = Nil, packagePins: Seq[String] = Nil, ioStandard: String = "LVCMOS33")
+  extends TracePMODPlacedOverlay(name, di, si)
 {
   def shell: XilinxShell
   val width = boardPins.size + packagePins.size

--- a/src/main/scala/shell/xilinx/UARTOverlay.scala
+++ b/src/main/scala/shell/xilinx/UARTOverlay.scala
@@ -6,8 +6,8 @@ import freechips.rocketchip.diplomacy._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.xilinx._
 
-abstract class UARTXilinxOverlay(params: UARTOverlayParams, flowControl: Boolean)
-  extends UARTOverlay(params, flowControl)
+abstract class UARTXilinxPlacedOverlay(name: String, di: UARTDesignInput, si: UARTShellInput, flowControl: Boolean)
+  extends UARTPlacedOverlay(name, di, si, flowControl)
 {
   def shell: XilinxShell
 

--- a/src/main/scala/shell/xilinx/UARTOverlay.scala
+++ b/src/main/scala/shell/xilinx/UARTOverlay.scala
@@ -10,4 +10,16 @@ abstract class UARTXilinxOverlay(params: UARTOverlayParams, flowControl: Boolean
   extends UARTOverlay(params, flowControl)
 {
   def shell: XilinxShell
+
+  InModuleBody {
+    val (io, _) = uartSource.out(0)
+    val tluartport = tluartSink.bundle
+    io <> tluartport
+    tluartport.rxd := RegNext(RegNext(io.rxd))
+  }
+
+  shell { InModuleBody {
+    UIntToAnalog(uartSink.bundle.txd, io.txd, true.B)
+    uartSink.bundle.rxd := AnalogToUInt(io.rxd)
+  } }
 }

--- a/src/main/scala/shell/xilinx/UltraScaleShell.scala
+++ b/src/main/scala/shell/xilinx/UltraScaleShell.scala
@@ -24,8 +24,8 @@ class XDMABridge(val numLanes: Int) extends Bundle {
   val ODIV2 = Input(Clock())
 }
 
-abstract class EthernetUltraScaleOverlay(config: XXVEthernetParams, params: EthernetOverlayParams)
-  extends EthernetOverlay(params)
+abstract class EthernetUltraScalePlacedOverlay(name: String, di: EthernetDesignInput, si: EthernetShellInput, config: XXVEthernetParams)
+  extends EthernetPlacedOverlay(name, di, si)
 {
   def shell: UltraScaleShell
 
@@ -45,7 +45,7 @@ abstract class EthernetUltraScaleOverlay(config: XXVEthernetParams, params: Ethe
     clocks.sys_reset     := Module.reset
 
     val macIO = pcs.module.io.mac
-    val pcsIO = designOutput
+    val pcsIO = overlayOutput.eth
     macIO.tx_mii_d_0 := pcsIO.tx_d
     macIO.tx_mii_c_0 := pcsIO.tx_c
     pcsIO.rx_d := macIO.rx_mii_d_0
@@ -76,8 +76,8 @@ abstract class EthernetUltraScaleOverlay(config: XXVEthernetParams, params: Ethe
   } }
 }
 
-abstract class PCIeUltraScaleOverlay(config: XDMAParams, params: PCIeOverlayParams)
-  extends PCIeOverlay[XDMATopPads](params)
+abstract class PCIeUltraScalePlacedOverlay(name: String, di: PCIeDesignInput, si: PCIeShellInput, config: XDMAParams)
+  extends PCIePlacedOverlay[XDMATopPads](name, di, si)
 {
   def shell: UltraScaleShell
 
@@ -87,7 +87,7 @@ abstract class PCIeUltraScaleOverlay(config: XDMAParams, params: PCIeOverlayPara
   val topBridge = shell { bridge.makeSink() }
   val axiClk    = ClockSourceNode(sdcClockName, freqMHz = config.axiMHz)
   val areset    = ClockSinkNode(Seq(ClockSinkParameters()))
-  areset := params.wrangler := axiClk
+  areset := di.wrangler := axiClk
 
   val slaveSide = TLIdentityNode()
   pcie.crossTLIn(pcie.slave)   := slaveSide
@@ -95,7 +95,7 @@ abstract class PCIeUltraScaleOverlay(config: XDMAParams, params: PCIeOverlayPara
   val node = NodeHandle(slaveSide, pcie.crossTLOut(pcie.master))
   val intnode = pcie.crossIntOut(pcie.intnode)
 
-  def designOutput = (node, intnode)
+  def overlayOutput = PCIeOverlayOutput(node, intnode)
   def ioFactory = new XDMATopPads(config.lanes)
 
   InModuleBody {

--- a/src/main/scala/shell/xilinx/VC707NewShell.scala
+++ b/src/main/scala/shell/xilinx/VC707NewShell.scala
@@ -77,17 +77,24 @@ class UARTVC707ShellPlacer(val shell: VC707Shell, val shellInput: UARTShellInput
 }
 
 class LEDVC707PlacedOverlay(val shell: VC707Shell, name: String, val designInput: LEDDesignInput, val shellInput: LEDShellInput)
-  extends LEDXilinxPlacedOverlay(name, designInput, shellInput, boardPins = Seq.tabulate(8) { i => s"leds_8bits_tri_o_$i" })
+  extends LEDXilinxPlacedOverlay(name, designInput, shellInput, boardPin = Some("leds_8bits_tri_o_$(shellInput.number)"))
 class LEDVC707ShellPlacer(val shell: VC707Shell, val shellInput: LEDShellInput)(implicit val valName: ValName)
   extends LEDShellPlacer[VC707Shell] {
   def place(designInput: LEDDesignInput) = new LEDVC707PlacedOverlay(shell, valName.name, designInput, shellInput)
 }
 
 class SwitchVC707PlacedOverlay(val shell: VC707Shell, name: String, val designInput: SwitchDesignInput, val shellInput: SwitchShellInput)
-  extends SwitchXilinxPlacedOverlay(name, designInput, shellInput, boardPins = Seq.tabulate(8) { i => s"dip_switches_tri_i_$i" })
+  extends SwitchXilinxPlacedOverlay(name, designInput, shellInput, boardPin = Some("dip_switches_tri_i_$(shellInput.number)"))
 class SwitchVC707ShellPlacer(val shell: VC707Shell, val shellInput: SwitchShellInput)(implicit val valName: ValName)
   extends SwitchShellPlacer[VC707Shell] {
   def place(designInput: SwitchDesignInput) = new SwitchVC707PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+
+class ButtonVC707PlacedOverlay(val shell: VC707Shell, name: String, val designInput: ButtonDesignInput, val shellInput: ButtonShellInput)
+  extends ButtonXilinxPlacedOverlay(name, designInput, shellInput, boardPin = Some("push_buttons_5bits_tri_i_$(shellInput.number)"))
+class ButtonVC707ShellPlacer(val shell: VC707Shell, val shellInput: ButtonShellInput)(implicit val valName: ValName)
+  extends ButtonShellPlacer[VC707Shell] {
+  def place(designInput: ButtonDesignInput) = new ButtonVC707PlacedOverlay(shell, valName.name, designInput, shellInput)
 }
 
 class ChipLinkVC707PlacedOverlay(val shell: VC707Shell, name: String, val designInput: ChipLinkDesignInput, val shellInput: ChipLinkShellInput)
@@ -262,8 +269,9 @@ abstract class VC707Shell()(implicit p: Parameters) extends Series7Shell
 
   // Order matters; ddr depends on sys_clock
   val sys_clock = Overlay(ClockInputOverlayKey, new SysClockVC707ShellPlacer(this, ClockInputShellInput()))
-  val led       = Overlay(LEDOverlayKey, new LEDVC707ShellPlacer(this, LEDShellInput()))
-  val switch    = Overlay(SwitchOverlayKey, new SwitchVC707ShellPlacer(this, SwitchShellInput()))
+  val led       = Seq.tabulate(8)(i => Overlay(LEDOverlayKey, new LEDVC707ShellPlacer(this, LEDShellInput(color = "red", number = i))(valName = ValName(s"led_$i"))))
+  val switch    = Seq.tabulate(8)(i => Overlay(SwitchOverlayKey, new SwitchVC707ShellPlacer(this, SwitchShellInput())(valName = ValName(s"switch_$i"))))
+  val button    = Seq.tabulate(5)(i => Overlay(ButtonOverlayKey, new ButtonVC707ShellPlacer(this, ButtonShellInput())(valName = ValName(s"button_$i"))))
   val chiplink  = Overlay(ChipLinkOverlayKey, new ChipLinkVC707ShellPlacer(this, ChipLinkShellInput()))
   val ddr       = Overlay(DDROverlayKey, new DDRVC707ShellPlacer(this, DDRShellInput()))
   val pcie      = Overlay(PCIeOverlayKey, new PCIeVC707ShellPlacer(this, PCIeShellInput()))

--- a/src/main/scala/shell/xilinx/VC707NewShell.scala
+++ b/src/main/scala/shell/xilinx/VC707NewShell.scala
@@ -14,8 +14,8 @@ import sifive.blocks.devices.chiplink._
 import sifive.fpgashells.devices.xilinx.xilinxvc707mig._
 import sifive.fpgashells.devices.xilinx.xilinxvc707pciex1._
 
-class SysClockVC707Overlay(val shell: VC707Shell, val name: String, params: ClockInputOverlayParams)
-  extends LVDSClockInputXilinxOverlay(params)
+class SysClockVC707PlacedOverlay(val shell: VC707Shell, name: String, val designInput: ClockInputDesignInput, val shellInput: ClockInputShellInput)
+  extends LVDSClockInputXilinxPlacedOverlay(name, designInput, shellInput)
 {
   val node = shell { ClockSourceNode(name, freqMHz = 200, jitterPS = 50) }
 
@@ -24,13 +24,13 @@ class SysClockVC707Overlay(val shell: VC707Shell, val name: String, params: Cloc
     shell.xdc.addBoardPin(io.n, "clk_n")
   } }
 }
-object SysClockVC707Overlay {
-  implicit object SysClockVC707Metadata extends HasMetadata[SysClockVC707Overlay] {
-    def metadata = OverlayMetadata()
-} }
+class SysClockVC707ShellPlacer(val shell: VC707Shell, val shellInput: ClockInputShellInput)(implicit val valName: ValName)
+  extends ClockInputShellPlacer[VC707Shell] {
+  def place(designInput: ClockInputDesignInput) = new SysClockVC707PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class SDIOVC707Overlay(val shell: VC707Shell, val name: String, params: SDIOOverlayParams)
-  extends SDIOXilinxOverlay(params)
+class SDIOVC707PlacedOverlay(val shell: VC707Shell, name: String, val designInput: SDIODesignInput, val shellInput: SDIOShellInput)
+  extends SDIOXilinxPlacedOverlay(name, designInput, shellInput)
 {
   shell { InModuleBody {
     val packagePinsWithPackageIOs = Seq(("AN30", IOPin(io.sdio_clk)),
@@ -50,13 +50,13 @@ class SDIOVC707Overlay(val shell: VC707Shell, val name: String, params: SDIOOver
     } }
   } }
 }
-object SDIOVC707Overlay {
-  implicit object SDIOVC707Metadata extends HasMetadata[SDIOVC707Overlay] {
-    def metadata = OverlayMetadata()
-} }
+class SDIOVC707ShellPlacer(val shell: VC707Shell, val shellInput: SDIOShellInput)(implicit val valName: ValName)
+  extends SDIOShellPlacer[VC707Shell] {
+  def place(designInput: SDIODesignInput) = new SDIOVC707PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class UARTVC707Overlay(val shell: VC707Shell, val name: String, params: UARTOverlayParams)
-  extends UARTXilinxOverlay(params, true)
+class UARTVC707PlacedOverlay(val shell: VC707Shell, name: String, val designInput: UARTDesignInput, val shellInput: UARTShellInput)
+  extends UARTXilinxPlacedOverlay(name, designInput, shellInput, true)
 {
   shell { InModuleBody {
     val packagePinsWithPackageIOs = Seq(("AT32", IOPin(io.ctsn.get)),
@@ -71,27 +71,27 @@ class UARTVC707Overlay(val shell: VC707Shell, val name: String, params: UARTOver
     } }
   } }
 }
-object UARTVC707Overlay {
-  implicit object UARTVC707Metadata extends HasMetadata[UARTVC707Overlay] {
-    def metadata = OverlayMetadata()
-} }
+class UARTVC707ShellPlacer(val shell: VC707Shell, val shellInput: UARTShellInput)(implicit val valName: ValName)
+  extends UARTShellPlacer[VC707Shell] {
+  def place(designInput: UARTDesignInput) = new UARTVC707PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class LEDVC707Overlay(val shell: VC707Shell, val name: String, params: LEDOverlayParams)
-  extends LEDXilinxOverlay(params, boardPins = Seq.tabulate(8) { i => s"leds_8bits_tri_o_$i" })
-object LEDVC707Overlay {
-  implicit object LEDVC707Metadata extends HasMetadata[LEDVC707Overlay] {
-    def metadata = OverlayMetadata()
-} }
+class LEDVC707PlacedOverlay(val shell: VC707Shell, name: String, val designInput: LEDDesignInput, val shellInput: LEDShellInput)
+  extends LEDXilinxPlacedOverlay(name, designInput, shellInput, boardPins = Seq.tabulate(8) { i => s"leds_8bits_tri_o_$i" })
+class LEDVC707ShellPlacer(val shell: VC707Shell, val shellInput: LEDShellInput)(implicit val valName: ValName)
+  extends LEDShellPlacer[VC707Shell] {
+  def place(designInput: LEDDesignInput) = new LEDVC707PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class SwitchVC707Overlay(val shell: VC707Shell, val name: String, params: SwitchOverlayParams)
-  extends SwitchXilinxOverlay(params, boardPins = Seq.tabulate(8) { i => s"dip_switches_tri_i_$i" })
-object SwitchVC707Overlay {
-  implicit object SwitchVC707Metadata extends HasMetadata[SwitchVC707Overlay] {
-    def metadata = OverlayMetadata()
-} }
+class SwitchVC707PlacedOverlay(val shell: VC707Shell, name: String, val designInput: SwitchDesignInput, val shellInput: SwitchShellInput)
+  extends SwitchXilinxPlacedOverlay(name, designInput, shellInput, boardPins = Seq.tabulate(8) { i => s"dip_switches_tri_i_$i" })
+class SwitchVC707ShellPlacer(val shell: VC707Shell, val shellInput: SwitchShellInput)(implicit val valName: ValName)
+  extends SwitchShellPlacer[VC707Shell] {
+  def place(designInput: SwitchDesignInput) = new SwitchVC707PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class ChipLinkVC707Overlay(val shell: VC707Shell, val name: String, params: ChipLinkOverlayParams)
-  extends ChipLinkXilinxOverlay(params, rxPhase=280, txPhase=220, rxMargin=0.3, txMargin=0.3)
+class ChipLinkVC707PlacedOverlay(val shell: VC707Shell, name: String, val designInput: ChipLinkDesignInput, val shellInput: ChipLinkShellInput)
+  extends ChipLinkXilinxPlacedOverlay(name, designInput, shellInput, rxPhase=280, txPhase=220, rxMargin=0.3, txMargin=0.3)
 {
   val ereset_n = shell { InModuleBody {
     val ereset_n = IO(Input(Bool()))
@@ -117,14 +117,14 @@ class ChipLinkVC707Overlay(val shell: VC707Shell, val name: String, params: Chip
     (IOPin.of(io.c2b) zip dir2) foreach { case (io, pin) => shell.xdc.addPackagePin(io, pin) }
   } }
 }
-object ChipLinkVC707Overlay {
-  implicit object ChipLinkVC707Metadata extends HasMetadata[ChipLinkVC707Overlay] {
-    def metadata = OverlayMetadata()
-} }
+class ChipLinkVC707ShellPlacer(val shell: VC707Shell, val shellInput: ChipLinkShellInput)(implicit val valName: ValName)
+  extends ChipLinkShellPlacer[VC707Shell] {
+  def place(designInput: ChipLinkDesignInput) = new ChipLinkVC707PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
 // TODO: JTAG is untested
-class JTAGDebugVC707Overlay(val shell: VC707Shell, val name: String, params: JTAGDebugOverlayParams)
-  extends JTAGDebugXilinxOverlay(params)
+class JTAGDebugVC707PlacedOverlay(val shell: VC707Shell, name: String, val designInput: JTAGDebugDesignInput, val shellInput: JTAGDebugShellInput)
+  extends JTAGDebugXilinxPlacedOverlay(name, designInput, shellInput)
 {
   shell { InModuleBody {
     shell.sdc.addClock("JTCK", IOPin(io.jtag_TCK), 10)
@@ -160,34 +160,34 @@ class JTAGDebugVC707Overlay(val shell: VC707Shell, val name: String, params: JTA
     } }
   } }
 }
-object JTAGDebugVC707Overlay {
-  implicit object JTAGDebugVC707Metadata extends HasMetadata[JTAGDebugVC707Overlay] {
-    def metadata = OverlayMetadata()
-} }
+class JTAGDebugVC707ShellPlacer(val shell: VC707Shell, val shellInput: JTAGDebugShellInput)(implicit val valName: ValName)
+  extends JTAGDebugShellPlacer[VC707Shell] {
+  def place(designInput: JTAGDebugDesignInput) = new JTAGDebugVC707PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
 case object VC707DDRSize extends Field[BigInt](0x40000000L * 1) // 1GB
-class DDRVC707Overlay(val shell: VC707Shell, val name: String, params: DDROverlayParams)
-  extends DDROverlay[XilinxVC707MIGPads](params)
+class DDRVC707PlacedOverlay(val shell: VC707Shell, name: String, val designInput: DDRDesignInput, val shellInput: DDRShellInput)
+  extends DDRPlacedOverlay[XilinxVC707MIGPads](name, designInput, shellInput)
 {
   val size = p(VC707DDRSize)
 
   val sdcClockName = "userClock1"
-  val migParams = XilinxVC707MIGParams(address = AddressSet.misaligned(params.baseAddress, size))
+  val migParams = XilinxVC707MIGParams(address = AddressSet.misaligned(designInput.baseAddress, size))
   val mig = LazyModule(new XilinxVC707MIG(migParams))
   val ioNode = BundleBridgeSource(() => mig.module.io.cloneType)
   val topIONode = shell { ioNode.makeSink() }
   val ddrUI     = shell { ClockSourceNode(sdcClockName, freqMHz = 200) }
   val areset    = shell { ClockSinkNode(Seq(ClockSinkParameters())) }
-  areset := params.wrangler := ddrUI
+  areset := designInput.wrangler := ddrUI
 
-  def designOutput = mig.node
+  def overlayOutput = DDROverlayOutput(ddr = mig.node)
   def ioFactory = new XilinxVC707MIGPads(size)
 
   InModuleBody { ioNode.bundle <> mig.module.io }
 
   shell { InModuleBody {
-    require (shell.sys_clock.isDefined, "Use of DDRVC707Overlay depends on SysClockVC707Overlay")
-    val (sys, _) = shell.sys_clock.get.node.out(0)
+    require (shell.sys_clock.get.isDefined, "Use of DDRVC707PlacedOverlay depends on SysClockVC707PlacedOverlay")
+    val (sys, _) = shell.sys_clock.get.get.overlayOutput.node.out(0)
     val (ui, _) = ddrUI.out(0)
     val (ar, _) = areset.in(0)
     val port = topIONode.bundle.port
@@ -201,13 +201,13 @@ class DDRVC707Overlay(val shell: VC707Shell, val name: String, params: DDROverla
 
   shell.sdc.addGroup(clocks = Seq("clk_pll_i"))
 }
-object DDRVC707Overlay {
-  implicit object DDRVC707Metadata extends HasMetadata[DDRVC707Overlay] {
-    def metadata = OverlayMetadata()
-} }
+class DDRVC707ShellPlacer(val shell: VC707Shell, val shellInput: DDRShellInput)(implicit val valName: ValName)
+  extends DDRShellPlacer[VC707Shell] {
+  def place(designInput: DDRDesignInput) = new DDRVC707PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class PCIeVC707Overlay(val shell: VC707Shell, val name: String, params: PCIeOverlayParams)
-  extends PCIeOverlay[XilinxVC707PCIeX1Pads](params)
+class PCIeVC707PlacedOverlay(val shell: VC707Shell, name: String, val designInput: PCIeDesignInput, val shellInput: PCIeShellInput)
+  extends PCIePlacedOverlay[XilinxVC707PCIeX1Pads](name, designInput, shellInput)
 {
   val sdcClockName = "axiClock"
   val pcie = LazyModule(new XilinxVC707PCIeX1)
@@ -215,7 +215,7 @@ class PCIeVC707Overlay(val shell: VC707Shell, val name: String, params: PCIeOver
   val topIONode = shell { ioNode.makeSink() }
   val axiClk    = shell { ClockSourceNode(sdcClockName, freqMHz = 125) }
   val areset    = shell { ClockSinkNode(Seq(ClockSinkParameters())) }
-  areset := params.wrangler := axiClk
+  areset := designInput.wrangler := axiClk
 
   val slaveSide = TLIdentityNode()
   pcie.crossTLIn(pcie.slave) := slaveSide
@@ -223,7 +223,7 @@ class PCIeVC707Overlay(val shell: VC707Shell, val name: String, params: PCIeOver
   val node = NodeHandle(slaveSide, pcie.crossTLOut(pcie.master))
   val intnode = pcie.crossIntOut(pcie.intnode)
 
-  def designOutput = (node, intnode)
+  def overlayOutput = PCIeOverlayOutput(node, intnode)
   def ioFactory = new XilinxVC707PCIeX1Pads
 
   InModuleBody { ioNode.bundle <> pcie.module.io }
@@ -250,10 +250,10 @@ class PCIeVC707Overlay(val shell: VC707Shell, val name: String, params: PCIeOver
 
   shell.sdc.addGroup(clocks = Seq("txoutclk", "userclk1", "axiClock"))
 }
-object PCIeVC707Overlay {
-  implicit object PCIeVC707Metadata extends HasMetadata[PCIeVC707Overlay] {
-    def metadata = OverlayMetadata()
-} }
+class PCIeVC707ShellPlacer(val shell: VC707Shell, val shellInput: PCIeShellInput)(implicit val valName: ValName)
+  extends PCIeShellPlacer[VC707Shell] {
+  def place(designInput: PCIeDesignInput) = new PCIeVC707PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
 abstract class VC707Shell()(implicit p: Parameters) extends Series7Shell
 {
@@ -261,14 +261,15 @@ abstract class VC707Shell()(implicit p: Parameters) extends Series7Shell
   val pllReset = InModuleBody { Wire(Bool()) }
 
   // Order matters; ddr depends on sys_clock
-  val sys_clock = Overlay(ClockInputOverlayKey)(new SysClockVC707Overlay(_, _, _))
-  val led       = Overlay(LEDOverlayKey)       (new LEDVC707Overlay     (_, _, _))
-  val switch    = Overlay(SwitchOverlayKey)    (new SwitchVC707Overlay  (_, _, _))
-  val chiplink  = Overlay(ChipLinkOverlayKey)  (new ChipLinkVC707Overlay(_, _, _))
-  val ddr       = Overlay(DDROverlayKey)       (new DDRVC707Overlay     (_, _, _))
-  val uart      = Overlay(UARTOverlayKey)      (new UARTVC707Overlay    (_, _, _))
-  val sdio      = Overlay(SDIOOverlayKey)      (new SDIOVC707Overlay    (_, _, _))
-  val jtag      = Overlay(JTAGDebugOverlayKey)      (new JTAGDebugVC707Overlay    (_, _, _))
+  val sys_clock = Overlay(ClockInputOverlayKey, new SysClockVC707ShellPlacer(this, ClockInputShellInput()))
+  val led       = Overlay(LEDOverlayKey, new LEDVC707ShellPlacer(this, LEDShellInput()))
+  val switch    = Overlay(SwitchOverlayKey, new SwitchVC707ShellPlacer(this, SwitchShellInput()))
+  val chiplink  = Overlay(ChipLinkOverlayKey, new ChipLinkVC707ShellPlacer(this, ChipLinkShellInput()))
+  val ddr       = Overlay(DDROverlayKey, new DDRVC707ShellPlacer(this, DDRShellInput()))
+  val pcie      = Overlay(PCIeOverlayKey, new PCIeVC707ShellPlacer(this, PCIeShellInput()))
+  val uart      = Overlay(UARTOverlayKey, new UARTVC707ShellPlacer(this, UARTShellInput()))
+  val sdio      = Overlay(SDIOOverlayKey, new SDIOVC707ShellPlacer(this, SDIOShellInput()))
+  val jtag      = Overlay(JTAGDebugOverlayKey, new JTAGDebugVC707ShellPlacer(this, JTAGDebugShellInput()))
 }
 
 class VC707BaseShell()(implicit p: Parameters) extends VC707Shell
@@ -285,22 +286,28 @@ class VC707BaseShell()(implicit p: Parameters) extends VC707Shell
     val reset_ibuf = Module(new IBUF)
     reset_ibuf.io.I := reset
 
-    val powerOnReset = PowerOnResetFPGAOnly(sys_clock.get.clock)
+    val sysclk: Clock = sys_clock.get() match {
+      case Some(x: SysClockVC707PlacedOverlay) => x.clock
+    }
+    val powerOnReset = PowerOnResetFPGAOnly(sysclk)
     sdc.addAsyncPath(Seq(powerOnReset))
 
+    val ereset: Bool = chiplink.get() match {
+      case Some(x: ChipLinkVCU118PlacedOverlay) => !x.ereset_n
+      case _ => false.B
+    }
     pllReset :=
-      reset_ibuf.io.O || powerOnReset ||
-      chiplink.map(!_.ereset_n).getOrElse(false.B)
+      reset_ibuf.io.O || powerOnReset || ereset
   }
 }
 
 class VC707PCIeShell()(implicit p: Parameters) extends VC707Shell
 {
-  val pcie      = Overlay(PCIeOverlayKey)      (new PCIeVC707Overlay    (_, _, _))
+  val pcie      = Overlay(PCIeOverlayKey, new PCIeVC707ShellPlacer(this, PCIeShellInput()))
   val topDesign = LazyModule(p(DesignKey)(designParameters))
 
   // Place the sys_clock at the Shell if the user didn't ask for it
-  p(ClockInputOverlayKey).foreach(_(ClockInputOverlayParams()))
+  p(ClockInputOverlayKey).foreach(_.place(ClockInputDesignInput()))
 
   override lazy val module = new LazyRawModuleImp(this) {
     val reset = IO(Input(Bool()))
@@ -308,12 +315,16 @@ class VC707PCIeShell()(implicit p: Parameters) extends VC707Shell
 
     val reset_ibuf = Module(new IBUF)
     reset_ibuf.io.I := reset
-
-    val powerOnReset = PowerOnResetFPGAOnly(sys_clock.get.clock)
+    val sysclk: Clock = sys_clock.get() match {
+      case Some(x: SysClockVC707PlacedOverlay) => x.clock
+    }
+    val powerOnReset = PowerOnResetFPGAOnly(sysclk)
     sdc.addAsyncPath(Seq(powerOnReset))
-
+    val ereset: Bool = chiplink.get() match {
+      case Some(x: ChipLinkVCU118PlacedOverlay) => !x.ereset_n
+      case _ => false.B
+    }
     pllReset :=
-      reset_ibuf.io.O || powerOnReset ||
-      chiplink.map(!_.ereset_n).getOrElse(false.B)
+      reset_ibuf.io.O || powerOnReset || ereset
   }
 }

--- a/src/main/scala/shell/xilinx/VC707NewShell.scala
+++ b/src/main/scala/shell/xilinx/VC707NewShell.scala
@@ -274,7 +274,6 @@ abstract class VC707Shell()(implicit p: Parameters) extends Series7Shell
   val button    = Seq.tabulate(5)(i => Overlay(ButtonOverlayKey, new ButtonVC707ShellPlacer(this, ButtonShellInput())(valName = ValName(s"button_$i"))))
   val chiplink  = Overlay(ChipLinkOverlayKey, new ChipLinkVC707ShellPlacer(this, ChipLinkShellInput()))
   val ddr       = Overlay(DDROverlayKey, new DDRVC707ShellPlacer(this, DDRShellInput()))
-  val pcie      = Overlay(PCIeOverlayKey, new PCIeVC707ShellPlacer(this, PCIeShellInput()))
   val uart      = Overlay(UARTOverlayKey, new UARTVC707ShellPlacer(this, UARTShellInput()))
   val sdio      = Overlay(SDIOOverlayKey, new SDIOVC707ShellPlacer(this, SDIOShellInput()))
   val jtag      = Overlay(JTAGDebugOverlayKey, new JTAGDebugVC707ShellPlacer(this, JTAGDebugShellInput()))
@@ -285,7 +284,7 @@ class VC707BaseShell()(implicit p: Parameters) extends VC707Shell
   val topDesign = LazyModule(p(DesignKey)(designParameters))
 
   // Place the sys_clock at the Shell if the user didn't ask for it
-  p(ClockInputOverlayKey).foreach(_(ClockInputOverlayParams()))
+  p(ClockInputOverlayKey).foreach(_.place(ClockInputDesignInput()))
 
   override lazy val module = new LazyRawModuleImp(this) {
     val reset = IO(Input(Bool()))

--- a/src/main/scala/shell/xilinx/VC707NewShell.scala
+++ b/src/main/scala/shell/xilinx/VC707NewShell.scala
@@ -24,6 +24,10 @@ class SysClockVC707Overlay(val shell: VC707Shell, val name: String, params: Cloc
     shell.xdc.addBoardPin(io.n, "clk_n")
   } }
 }
+object SysClockVC707Overlay {
+  implicit object SysClockVC707Metadata extends HasMetadata[SysClockVC707Overlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class SDIOVC707Overlay(val shell: VC707Shell, val name: String, params: SDIOOverlayParams)
   extends SDIOXilinxOverlay(params)
@@ -46,6 +50,10 @@ class SDIOVC707Overlay(val shell: VC707Shell, val name: String, params: SDIOOver
     } }
   } }
 }
+object SDIOVC707Overlay {
+  implicit object SDIOVC707Metadata extends HasMetadata[SDIOVC707Overlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class UARTVC707Overlay(val shell: VC707Shell, val name: String, params: UARTOverlayParams)
   extends UARTXilinxOverlay(params, true)
@@ -63,12 +71,24 @@ class UARTVC707Overlay(val shell: VC707Shell, val name: String, params: UARTOver
     } }
   } }
 }
+object UARTVC707Overlay {
+  implicit object UARTVC707Metadata extends HasMetadata[UARTVC707Overlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class LEDVC707Overlay(val shell: VC707Shell, val name: String, params: LEDOverlayParams)
   extends LEDXilinxOverlay(params, boardPins = Seq.tabulate(8) { i => s"leds_8bits_tri_o_$i" })
+object LEDVC707Overlay {
+  implicit object LEDVC707Metadata extends HasMetadata[LEDVC707Overlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class SwitchVC707Overlay(val shell: VC707Shell, val name: String, params: SwitchOverlayParams)
   extends SwitchXilinxOverlay(params, boardPins = Seq.tabulate(8) { i => s"dip_switches_tri_i_$i" })
+object SwitchVC707Overlay {
+  implicit object SwitchVC707Metadata extends HasMetadata[SwitchVC707Overlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class ChipLinkVC707Overlay(val shell: VC707Shell, val name: String, params: ChipLinkOverlayParams)
   extends ChipLinkXilinxOverlay(params, rxPhase=280, txPhase=220, rxMargin=0.3, txMargin=0.3)
@@ -97,6 +117,10 @@ class ChipLinkVC707Overlay(val shell: VC707Shell, val name: String, params: Chip
     (IOPin.of(io.c2b) zip dir2) foreach { case (io, pin) => shell.xdc.addPackagePin(io, pin) }
   } }
 }
+object ChipLinkVC707Overlay {
+  implicit object ChipLinkVC707Metadata extends HasMetadata[ChipLinkVC707Overlay] {
+    def metadata = OverlayMetadata()
+} }
 
 // TODO: JTAG is untested
 class JTAGDebugVC707Overlay(val shell: VC707Shell, val name: String, params: JTAGDebugOverlayParams)
@@ -136,6 +160,10 @@ class JTAGDebugVC707Overlay(val shell: VC707Shell, val name: String, params: JTA
     } }
   } }
 }
+object JTAGDebugVC707Overlay {
+  implicit object JTAGDebugVC707Metadata extends HasMetadata[JTAGDebugVC707Overlay] {
+    def metadata = OverlayMetadata()
+} }
 
 case object VC707DDRSize extends Field[BigInt](0x40000000L * 1) // 1GB
 class DDRVC707Overlay(val shell: VC707Shell, val name: String, params: DDROverlayParams)
@@ -173,6 +201,10 @@ class DDRVC707Overlay(val shell: VC707Shell, val name: String, params: DDROverla
 
   shell.sdc.addGroup(clocks = Seq("clk_pll_i"))
 }
+object DDRVC707Overlay {
+  implicit object DDRVC707Metadata extends HasMetadata[DDRVC707Overlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class PCIeVC707Overlay(val shell: VC707Shell, val name: String, params: PCIeOverlayParams)
   extends PCIeOverlay[XilinxVC707PCIeX1Pads](params)
@@ -218,6 +250,10 @@ class PCIeVC707Overlay(val shell: VC707Shell, val name: String, params: PCIeOver
 
   shell.sdc.addGroup(clocks = Seq("txoutclk", "userclk1", "axiClock"))
 }
+object PCIeVC707Overlay {
+  implicit object PCIeVC707Metadata extends HasMetadata[PCIeVC707Overlay] {
+    def metadata = OverlayMetadata()
+} }
 
 abstract class VC707Shell()(implicit p: Parameters) extends Series7Shell
 {

--- a/src/main/scala/shell/xilinx/VCU118NewShell.scala
+++ b/src/main/scala/shell/xilinx/VCU118NewShell.scala
@@ -27,6 +27,10 @@ class SysClockVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: Strin
     shell.xdc.addIOStandard(io.n, "DIFF_SSTL12")
   } }
 }
+object SysClockVCU118Overlay {
+  implicit object SysClockVCU118Metadata extends HasMetadata[SysClockVCU118Overlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class RefClockVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: ClockInputOverlayParams)
   extends LVDSClockInputXilinxOverlay(params)
@@ -40,6 +44,10 @@ class RefClockVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: Strin
     shell.xdc.addIOStandard(io.n, "LVDS")
   } }
 }
+object RefClockVCU118Overlay {
+  implicit object RefClockVCU118Metadata extends HasMetadata[RefClockVCU118Overlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class SDIOVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: SDIOOverlayParams)
   extends SDIOXilinxOverlay(params)
@@ -62,6 +70,10 @@ class SDIOVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, p
     } }
   } }
 }
+object SDIOVCU118Overlay {
+  implicit object SDIOVCU118Metadata extends HasMetadata[SDIOVCU118Overlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class SPIFlashVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: SPIFlashOverlayParams)
   extends SPIFlashXilinxOverlay(params)
@@ -84,6 +96,10 @@ class SPIFlashVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: Strin
     //} }
   } }
 }
+object SPIFlashVCU118Overlay {
+  implicit object SPIFlashVCU118Metadata extends HasMetadata[SPIFlashVCU118Overlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class UARTVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: UARTOverlayParams)
   extends UARTXilinxOverlay(params, true)
@@ -101,6 +117,10 @@ class UARTVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, p
     } }
   } }
 }
+object UARTVCU118Overlay {
+  implicit object UARTVCU118Metadata extends HasMetadata[UARTVCU118Overlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class QSFP1VCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: EthernetOverlayParams)
   extends EthernetUltraScaleOverlay(XXVEthernetParams(
@@ -123,6 +143,10 @@ class QSFP1VCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, 
     shell.xdc.addPackagePin(io.refclk_n, "W8")
   } }
 }
+object QSFP1VCU118Overlay {
+  implicit object QSFP1VCU118Metadata extends HasMetadata[QSFP1VCU118Overlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class QSFP2VCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: EthernetOverlayParams)
   extends EthernetUltraScaleOverlay(XXVEthernetParams(
@@ -145,6 +169,10 @@ class QSFP2VCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, 
     shell.xdc.addPackagePin(io.refclk_n, "R8")
   } }
 }
+object QSFP2VCU118Overlay {
+  implicit object QSFP2VCU118Metadata extends HasMetadata[QSFP2VCU118Overlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class LEDVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: LEDOverlayParams)
   extends LEDXilinxOverlay(params, packagePins = Seq("AT32", "AV34", "AY30", "BB32", "BF32", "AU37", "AV36", "BA37"))
@@ -153,6 +181,10 @@ class LEDVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, pa
     IOPin.of(io).foreach { shell.xdc.addIOStandard(_, "LVCMOS12") }
   } }
 }
+object LEDVCU118Overlay {
+  implicit object LEDVCU118Metadata extends HasMetadata[LEDVCU118Overlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class SwitchVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: SwitchOverlayParams)
   extends SwitchXilinxOverlay(params, packagePins = Seq("B17", "G16", "J16", "D21"))
@@ -161,6 +193,10 @@ class SwitchVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String,
     IOPin.of(io).foreach { shell.xdc.addIOStandard(_, "LVCMOS12") }
   } }
 }
+object SwitchVCU118Overlay {
+  implicit object SwitchVCU118Metadata extends HasMetadata[SwitchVCU118Overlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class ChipLinkVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: ChipLinkOverlayParams)
   extends ChipLinkXilinxOverlay(params, rxPhase= -120, txPhase= -90, rxMargin=0.6, txMargin=0.5)
@@ -198,6 +234,10 @@ class ChipLinkVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: Strin
     (IOPin.of(io.c2b) zip dir2) foreach { case (io, pin) => shell.xdc.addPackagePin(io, pin) }
   } }
 }
+object ChipLinkVCU118Overlay {
+  implicit object ChipLinkVCU118Metadata extends HasMetadata[ChipLinkVCU118Overlay] {
+    def metadata = OverlayMetadata()
+} }
 
 // TODO: JTAG is untested
 class JTAGDebugVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: JTAGDebugOverlayParams)
@@ -219,6 +259,10 @@ class JTAGDebugVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: Stri
     } }
   } }
 }
+object JTAGDebugVCU118Overlay {
+  implicit object JTAGDebugVCU118Metadata extends HasMetadata[JTAGDebugVCU118Overlay] {
+    def metadata = OverlayMetadata()
+} }
 
 case object VCU118DDRSize extends Field[BigInt](0x40000000L * 2) // 2GB
 class DDRVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: DDROverlayParams)
@@ -271,6 +315,10 @@ class DDRVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, pa
 
   shell.sdc.addGroup(clocks = Seq("userClock1"))
 }
+object DDRVCU118Overlay {
+  implicit object DDRVCU118Metadata extends HasMetadata[DDRVCU118Overlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class PCIeVCU118FMCOverlay(val shell: VCU118ShellBasicOverlays, val name: String, params: PCIeOverlayParams)
   extends PCIeUltraScaleOverlay(XDMAParams(
@@ -307,6 +355,10 @@ class PCIeVCU118FMCOverlay(val shell: VCU118ShellBasicOverlays, val name: String
     bind(IOPin.of(io.lanes.pci_exp_rxn), rxn)
   } }
 }
+object PCIeVCU118FMCOverlay {
+  implicit object PCIeVCU118FMCMetadata extends HasMetadata[PCIeVCU118FMCOverlay] {
+    def metadata = OverlayMetadata()
+} }
 
 class PCIeVCU118EdgeOverlay(val shell: VCU118ShellBasicOverlays, val name: String, params: PCIeOverlayParams)
   extends PCIeUltraScaleOverlay(XDMAParams(
@@ -348,6 +400,10 @@ class PCIeVCU118EdgeOverlay(val shell: VCU118ShellBasicOverlays, val name: Strin
     bind(IOPin.of(io.lanes.pci_exp_rxn), rxn)
   } }
 }
+object PCIeVCU118EdgeOverlay {
+  implicit object PCIeVCU118FMCMetadata extends HasMetadata[PCIeVCU118EdgeOverlay] {
+    def metadata = OverlayMetadata()
+} }
 
 abstract class VCU118ShellBasicOverlays()(implicit p: Parameters) extends UltraScaleShell{
   val sys_clock = Overlay(ClockInputOverlayKey)(new SysClockVCU118Overlay (_, _, _))

--- a/src/main/scala/shell/xilinx/VCU118NewShell.scala
+++ b/src/main/scala/shell/xilinx/VCU118NewShell.scala
@@ -168,25 +168,21 @@ class QSFP2VCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: Et
   def place(designInput: EthernetDesignInput) = new QSFP2VCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
 }
 
-class LEDVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: LEDDesignInput, val shellInput: LEDShellInput)
-  extends LEDXilinxPlacedOverlay(name, designInput, shellInput, packagePins = Seq("AT32", "AV34", "AY30", "BB32", "BF32", "AU37", "AV36", "BA37"))
-{
-  shell { InModuleBody {
-    IOPin.of(io).foreach { shell.xdc.addIOStandard(_, "LVCMOS12") }
-  } }
+object LEDVCU118PinConstraints {
+  val pins = Seq("AT32", "AV34", "AY30", "BB32", "BF32", "AU37", "AV36", "BA37")
 }
+class LEDVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: LEDDesignInput, val shellInput: LEDShellInput)
+  extends LEDXilinxPlacedOverlay(name, designInput, shellInput, packagePin = Some(LEDVCU118PinConstraints.pins(shellInput.number)), ioStandard = "LVCMOS12")
 class LEDVCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: LEDShellInput)(implicit val valName: ValName)
   extends LEDShellPlacer[VCU118ShellBasicOverlays] {
   def place(designInput: LEDDesignInput) = new LEDVCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
 }
 
-class SwitchVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: SwitchDesignInput, val shellInput: SwitchShellInput)
-  extends SwitchXilinxPlacedOverlay(name, designInput, shellInput, packagePins = Seq("B17", "G16", "J16", "D21"))
-{
-  shell { InModuleBody {
-    IOPin.of(io).foreach { shell.xdc.addIOStandard(_, "LVCMOS12") }
-  } }
+object SwitchVCU118PinConstraints {
+  val pins = Seq("B17", "G16", "J16", "D21")
 }
+class SwitchVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: SwitchDesignInput, val shellInput: SwitchShellInput)
+  extends SwitchXilinxPlacedOverlay(name, designInput, shellInput, packagePin = Some(SwitchVCU118PinConstraints.pins(shellInput.number)), ioStandard = "LVCMOS12")
 class SwitchVCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: SwitchShellInput)(implicit val valName: ValName)
   extends SwitchShellPlacer[VCU118ShellBasicOverlays] {
   def place(designInput: SwitchDesignInput) = new SwitchVCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
@@ -402,8 +398,8 @@ class PCIeVCU118EdgeShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput:
 abstract class VCU118ShellBasicOverlays()(implicit p: Parameters) extends UltraScaleShell{
   val sys_clock = Overlay(ClockInputOverlayKey, new SysClockVCU118ShellPlacer(this, ClockInputShellInput()))
   val ref_clock = Overlay(ClockInputOverlayKey, new RefClockVCU118ShellPlacer(this, ClockInputShellInput()))
-  val led       = Overlay(LEDOverlayKey, new LEDVCU118ShellPlacer(this, LEDShellInput()))
-  val switch    = Overlay(SwitchOverlayKey, new SwitchVCU118ShellPlacer(this, SwitchShellInput()))
+  val led       = Seq.tabulate(8)(i => Overlay(LEDOverlayKey, new LEDVCU118ShellPlacer(this, LEDShellInput(color = "red", number = i))(valName = ValName(s"led_$i"))))
+  val switch    = Seq.tabulate(4)(i => Overlay(SwitchOverlayKey, new SwitchVCU118ShellPlacer(this, SwitchShellInput(number = i))(valName = ValName(s"switch_$i"))))
   val ddr       = Overlay(DDROverlayKey, new DDRVCU118ShellPlacer(this, DDRShellInput()))
   val uart      = Overlay(UARTOverlayKey, new UARTVCU118ShellPlacer(this, UARTShellInput()))
   val sdio      = Overlay(SDIOOverlayKey, new SDIOVCU118ShellPlacer(this, SDIOShellInput()))

--- a/src/main/scala/shell/xilinx/VCU118NewShell.scala
+++ b/src/main/scala/shell/xilinx/VCU118NewShell.scala
@@ -70,10 +70,10 @@ class SPIFlashVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: Strin
   shell { InModuleBody { 
     val packagePinsWithPackageIOs = Seq(("AF13", IOPin(io.qspi_sck)),
       ("AJ11", IOPin(io.qspi_cs)),
-      ("AP11", IOPin(io.qspi_dq_0)),
-      ("AN11", IOPin(io.qspi_dq_1)),
-      ("AM11", IOPin(io.qspi_dq_2)),
-      ("AL11", IOPin(io.qspi_dq_3)))
+      ("AP11", IOPin(io.qspi_dq(0))),
+      ("AN11", IOPin(io.qspi_dq(1))),
+      ("AM11", IOPin(io.qspi_dq(2))),
+      ("AL11", IOPin(io.qspi_dq(3))))
 
     packagePinsWithPackageIOs foreach { case (pin, io) => {
       shell.xdc.addPackagePin(io, pin)

--- a/src/main/scala/shell/xilinx/VCU118NewShell.scala
+++ b/src/main/scala/shell/xilinx/VCU118NewShell.scala
@@ -15,8 +15,8 @@ import sifive.fpgashells.devices.xilinx.xilinxvcu118mig._
 import sifive.fpgashells.devices.xilinx.xdma._
 import sifive.fpgashells.ip.xilinx.xxv_ethernet._
 
-class SysClockVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: ClockInputOverlayParams)
-  extends LVDSClockInputXilinxOverlay(params)
+class SysClockVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: ClockInputDesignInput, val shellInput: ClockInputShellInput)
+  extends LVDSClockInputXilinxPlacedOverlay(name, designInput, shellInput) 
 {
   val node = shell { ClockSourceNode(name, freqMHz = 250, jitterPS = 50) }
 
@@ -27,14 +27,14 @@ class SysClockVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: Strin
     shell.xdc.addIOStandard(io.n, "DIFF_SSTL12")
   } }
 }
-object SysClockVCU118Overlay {
-  implicit object SysClockVCU118Metadata extends HasMetadata[SysClockVCU118Overlay] {
-    def metadata = OverlayMetadata()
-} }
-
-class RefClockVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: ClockInputOverlayParams)
-  extends LVDSClockInputXilinxOverlay(params)
+class SysClockVCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: ClockInputShellInput)(implicit val valName: ValName)
+  extends ClockInputShellPlacer[VCU118ShellBasicOverlays]
 {
+    def place(designInput: ClockInputDesignInput) = new SysClockVCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+
+class RefClockVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: ClockInputDesignInput, val shellInput: ClockInputShellInput)
+  extends LVDSClockInputXilinxPlacedOverlay(name, designInput, shellInput) {
   val node = shell { ClockSourceNode(name, freqMHz = 125, jitterPS = 50) }
 
   shell { InModuleBody {
@@ -44,13 +44,13 @@ class RefClockVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: Strin
     shell.xdc.addIOStandard(io.n, "LVDS")
   } }
 }
-object RefClockVCU118Overlay {
-  implicit object RefClockVCU118Metadata extends HasMetadata[RefClockVCU118Overlay] {
-    def metadata = OverlayMetadata()
-} }
+class RefClockVCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: ClockInputShellInput)(implicit val valName: ValName)
+  extends ClockInputShellPlacer[VCU118ShellBasicOverlays] {
+  def place(designInput: ClockInputDesignInput) = new RefClockVCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class SDIOVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: SDIOOverlayParams)
-  extends SDIOXilinxOverlay(params)
+class SDIOVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: SDIODesignInput, val shellInput: SDIOShellInput)
+  extends SDIOXilinxPlacedOverlay(name, designInput, shellInput)
 {
   shell { InModuleBody {
     val packagePinsWithPackageIOs = Seq(("AV15", IOPin(io.sdio_clk)),
@@ -70,13 +70,13 @@ class SDIOVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, p
     } }
   } }
 }
-object SDIOVCU118Overlay {
-  implicit object SDIOVCU118Metadata extends HasMetadata[SDIOVCU118Overlay] {
-    def metadata = OverlayMetadata()
-} }
+class SDIOVCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: SDIOShellInput)(implicit val valName: ValName)
+  extends SDIOShellPlacer[VCU118ShellBasicOverlays] {
+  def place(designInput: SDIODesignInput) = new SDIOVCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class SPIFlashVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: SPIFlashOverlayParams)
-  extends SPIFlashXilinxOverlay(params)
+class SPIFlashVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: SPIFlashDesignInput, val shellInput: SPIFlashShellInput)
+  extends SPIFlashXilinxPlacedOverlay(name, designInput, shellInput)
 {
 
   shell { InModuleBody { 
@@ -96,13 +96,13 @@ class SPIFlashVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: Strin
     //} }
   } }
 }
-object SPIFlashVCU118Overlay {
-  implicit object SPIFlashVCU118Metadata extends HasMetadata[SPIFlashVCU118Overlay] {
-    def metadata = OverlayMetadata()
-} }
+class SPIFlashVCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: SPIFlashShellInput)(implicit val valName: ValName)
+  extends SPIFlashShellPlacer[VCU118ShellBasicOverlays] {
+  def place(designInput: SPIFlashDesignInput) = new SPIFlashVCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class UARTVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: UARTOverlayParams)
-  extends UARTXilinxOverlay(params, true)
+class UARTVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: UARTDesignInput, val shellInput: UARTShellInput)
+  extends UARTXilinxPlacedOverlay(name, designInput, shellInput, true)
 {
   shell { InModuleBody {
     val packagePinsWithPackageIOs = Seq(("AY25", IOPin(io.ctsn.get)),
@@ -117,16 +117,13 @@ class UARTVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, p
     } }
   } }
 }
-object UARTVCU118Overlay {
-  implicit object UARTVCU118Metadata extends HasMetadata[UARTVCU118Overlay] {
-    def metadata = OverlayMetadata()
-} }
+class UARTVCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: UARTShellInput)(implicit val valName: ValName)
+  extends UARTShellPlacer[VCU118ShellBasicOverlays] {
+  def place(designInput: UARTDesignInput) = new UARTVCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class QSFP1VCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: EthernetOverlayParams)
-  extends EthernetUltraScaleOverlay(XXVEthernetParams(
-    name    = name,
-    speed   = 10,
-    dclkMHz = 125), params)
+class QSFP1VCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: EthernetDesignInput, val shellInput: EthernetShellInput)
+  extends EthernetUltraScalePlacedOverlay(name, designInput, shellInput, XXVEthernetParams(name = name, speed   = 10, dclkMHz = 125))
 {
   val dclkSource = shell { BundleBridgeSource(() => Clock()) }
   val dclkSink = dclkSource.makeSink()
@@ -134,7 +131,7 @@ class QSFP1VCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, 
     dclk := dclkSink.bundle
   }
   shell { InModuleBody {
-    dclkSource.bundle := shell.ref_clock.get.node.out(0)._1.clock
+    dclkSource.bundle := shell.ref_clock.get.get.overlayOutput.node.out(0)._1.clock
     shell.xdc.addPackagePin(io.tx_p, "V7")
     shell.xdc.addPackagePin(io.tx_n, "V6")
     shell.xdc.addPackagePin(io.rx_p, "Y2")
@@ -143,16 +140,13 @@ class QSFP1VCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, 
     shell.xdc.addPackagePin(io.refclk_n, "W8")
   } }
 }
-object QSFP1VCU118Overlay {
-  implicit object QSFP1VCU118Metadata extends HasMetadata[QSFP1VCU118Overlay] {
-    def metadata = OverlayMetadata()
-} }
+class QSFP1VCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: EthernetShellInput)(implicit val valName: ValName)
+  extends EthernetShellPlacer[VCU118ShellBasicOverlays] {
+  def place(designInput: EthernetDesignInput) = new QSFP1VCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class QSFP2VCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: EthernetOverlayParams)
-  extends EthernetUltraScaleOverlay(XXVEthernetParams(
-    name    = name,
-    speed   = 10,
-    dclkMHz = 125), params)
+class QSFP2VCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: EthernetDesignInput, val shellInput: EthernetShellInput)
+  extends EthernetUltraScalePlacedOverlay(name, designInput, shellInput, XXVEthernetParams(name = name, speed   = 10, dclkMHz = 125))
 {
   val dclkSource = shell { BundleBridgeSource(() => Clock()) }
   val dclkSink = dclkSource.makeSink()
@@ -160,7 +154,7 @@ class QSFP2VCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, 
     dclk := dclkSink.bundle
   }
   shell { InModuleBody {
-    dclkSource.bundle := shell.ref_clock.get.node.out(0)._1.clock
+    dclkSource.bundle := shell.ref_clock.get.get.overlayOutput.node.out(0)._1.clock
     shell.xdc.addPackagePin(io.tx_p, "L5")
     shell.xdc.addPackagePin(io.tx_n, "L4")
     shell.xdc.addPackagePin(io.rx_p, "T2")
@@ -169,37 +163,37 @@ class QSFP2VCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, 
     shell.xdc.addPackagePin(io.refclk_n, "R8")
   } }
 }
-object QSFP2VCU118Overlay {
-  implicit object QSFP2VCU118Metadata extends HasMetadata[QSFP2VCU118Overlay] {
-    def metadata = OverlayMetadata()
-} }
+class QSFP2VCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: EthernetShellInput)(implicit val valName: ValName)
+  extends EthernetShellPlacer[VCU118ShellBasicOverlays] {
+  def place(designInput: EthernetDesignInput) = new QSFP2VCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class LEDVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: LEDOverlayParams)
-  extends LEDXilinxOverlay(params, packagePins = Seq("AT32", "AV34", "AY30", "BB32", "BF32", "AU37", "AV36", "BA37"))
+class LEDVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: LEDDesignInput, val shellInput: LEDShellInput)
+  extends LEDXilinxPlacedOverlay(name, designInput, shellInput, packagePins = Seq("AT32", "AV34", "AY30", "BB32", "BF32", "AU37", "AV36", "BA37"))
 {
   shell { InModuleBody {
     IOPin.of(io).foreach { shell.xdc.addIOStandard(_, "LVCMOS12") }
   } }
 }
-object LEDVCU118Overlay {
-  implicit object LEDVCU118Metadata extends HasMetadata[LEDVCU118Overlay] {
-    def metadata = OverlayMetadata()
-} }
+class LEDVCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: LEDShellInput)(implicit val valName: ValName)
+  extends LEDShellPlacer[VCU118ShellBasicOverlays] {
+  def place(designInput: LEDDesignInput) = new LEDVCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class SwitchVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: SwitchOverlayParams)
-  extends SwitchXilinxOverlay(params, packagePins = Seq("B17", "G16", "J16", "D21"))
+class SwitchVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: SwitchDesignInput, val shellInput: SwitchShellInput)
+  extends SwitchXilinxPlacedOverlay(name, designInput, shellInput, packagePins = Seq("B17", "G16", "J16", "D21"))
 {
   shell { InModuleBody {
     IOPin.of(io).foreach { shell.xdc.addIOStandard(_, "LVCMOS12") }
   } }
 }
-object SwitchVCU118Overlay {
-  implicit object SwitchVCU118Metadata extends HasMetadata[SwitchVCU118Overlay] {
-    def metadata = OverlayMetadata()
-} }
+class SwitchVCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: SwitchShellInput)(implicit val valName: ValName)
+  extends SwitchShellPlacer[VCU118ShellBasicOverlays] {
+  def place(designInput: SwitchDesignInput) = new SwitchVCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class ChipLinkVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: ChipLinkOverlayParams)
-  extends ChipLinkXilinxOverlay(params, rxPhase= -120, txPhase= -90, rxMargin=0.6, txMargin=0.5)
+class ChipLinkVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: ChipLinkDesignInput, val shellInput: ChipLinkShellInput)
+  extends ChipLinkXilinxPlacedOverlay(name, designInput, shellInput, rxPhase= -120, txPhase= -90, rxMargin=0.6, txMargin=0.5)
 {
   val ereset_n = shell { InModuleBody {
     val ereset_n = IO(Analog(1.W))
@@ -234,14 +228,14 @@ class ChipLinkVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: Strin
     (IOPin.of(io.c2b) zip dir2) foreach { case (io, pin) => shell.xdc.addPackagePin(io, pin) }
   } }
 }
-object ChipLinkVCU118Overlay {
-  implicit object ChipLinkVCU118Metadata extends HasMetadata[ChipLinkVCU118Overlay] {
-    def metadata = OverlayMetadata()
-} }
+class ChipLinkVCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: ChipLinkShellInput)(implicit val valName: ValName)
+  extends ChipLinkShellPlacer[VCU118ShellBasicOverlays] {
+  def place(designInput: ChipLinkDesignInput) = new ChipLinkVCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
 // TODO: JTAG is untested
-class JTAGDebugVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: JTAGDebugOverlayParams)
-  extends JTAGDebugXilinxOverlay(params)
+class JTAGDebugVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: JTAGDebugDesignInput, val shellInput: JTAGDebugShellInput)
+  extends JTAGDebugXilinxPlacedOverlay(name, designInput, shellInput)
 {
   shell { InModuleBody {
     shell.sdc.addClock("JTCK", IOPin(io.jtag_TCK), 10)
@@ -259,34 +253,34 @@ class JTAGDebugVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: Stri
     } }
   } }
 }
-object JTAGDebugVCU118Overlay {
-  implicit object JTAGDebugVCU118Metadata extends HasMetadata[JTAGDebugVCU118Overlay] {
-    def metadata = OverlayMetadata()
-} }
+class JTAGDebugVCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: JTAGDebugShellInput)(implicit val valName: ValName)
+  extends JTAGDebugShellPlacer[VCU118ShellBasicOverlays] {
+  def place(designInput: JTAGDebugDesignInput) = new JTAGDebugVCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
 case object VCU118DDRSize extends Field[BigInt](0x40000000L * 2) // 2GB
-class DDRVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, params: DDROverlayParams)
-  extends DDROverlay[XilinxVCU118MIGPads](params)
+class DDRVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: DDRDesignInput, val shellInput: DDRShellInput)
+  extends DDRPlacedOverlay[XilinxVCU118MIGPads](name, designInput, shellInput)
 {
   val size = p(VCU118DDRSize)
 
   val sdcClockName = "userClock1"
-  val migParams = XilinxVCU118MIGParams(address = AddressSet.misaligned(params.baseAddress, size))
+  val migParams = XilinxVCU118MIGParams(address = AddressSet.misaligned(designInput.baseAddress, size))
   val mig = LazyModule(new XilinxVCU118MIG(migParams))
   val ioNode = BundleBridgeSource(() => mig.module.io.cloneType)
   val topIONode = shell { ioNode.makeSink() }
   val ddrUI     = shell { ClockSourceNode(sdcClockName, freqMHz = 200) }
   val areset    = shell { ClockSinkNode(Seq(ClockSinkParameters())) }
-  areset := params.wrangler := ddrUI
+  areset := designInput.wrangler := ddrUI
 
-  def designOutput = mig.node
+  def overlayOutput = DDROverlayOutput(ddr = mig.node)
   def ioFactory = new XilinxVCU118MIGPads(size)
 
   InModuleBody { ioNode.bundle <> mig.module.io }
 
   shell { InModuleBody {
-    require (shell.sys_clock.isDefined, "Use of DDRVCU118Overlay depends on SysClockVCU118Overlay")
-    val (sys, _) = shell.sys_clock.get.node.out(0)
+    require (shell.sys_clock.get.isDefined, "Use of DDRVCU118Overlay depends on SysClockVCU118Overlay")
+    val (sys, _) = shell.sys_clock.get.get.overlayOutput.node.out(0)
     val (ui, _) = ddrUI.out(0)
     val (ar, _) = areset.in(0)
     val port = topIONode.bundle.port
@@ -315,18 +309,18 @@ class DDRVCU118Overlay(val shell: VCU118ShellBasicOverlays, val name: String, pa
 
   shell.sdc.addGroup(clocks = Seq("userClock1"))
 }
-object DDRVCU118Overlay {
-  implicit object DDRVCU118Metadata extends HasMetadata[DDRVCU118Overlay] {
-    def metadata = OverlayMetadata()
-} }
+class DDRVCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: DDRShellInput)(implicit val valName: ValName)
+  extends DDRShellPlacer[VCU118ShellBasicOverlays] {
+  def place(designInput: DDRDesignInput) = new DDRVCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class PCIeVCU118FMCOverlay(val shell: VCU118ShellBasicOverlays, val name: String, params: PCIeOverlayParams)
-  extends PCIeUltraScaleOverlay(XDMAParams(
+class PCIeVCU118FMCPlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: PCIeDesignInput, val shellInput: PCIeShellInput)
+  extends PCIeUltraScalePlacedOverlay(name, designInput, shellInput, XDMAParams(
     name     = "fmc_xdma",
     location = "X0Y3",
-    bars     = params.bars,
-    control  = params.ecam,
-    lanes    = 4), params)
+    bars     = designInput.bars,
+    control  = designInput.ecam,
+    lanes    = 4))
 {
   shell { InModuleBody {
     // Work-around incorrectly pre-assigned pins
@@ -355,18 +349,18 @@ class PCIeVCU118FMCOverlay(val shell: VCU118ShellBasicOverlays, val name: String
     bind(IOPin.of(io.lanes.pci_exp_rxn), rxn)
   } }
 }
-object PCIeVCU118FMCOverlay {
-  implicit object PCIeVCU118FMCMetadata extends HasMetadata[PCIeVCU118FMCOverlay] {
-    def metadata = OverlayMetadata()
-} }
+class PCIeVCU118FMCShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: PCIeShellInput)(implicit val valName: ValName)
+  extends PCIeShellPlacer[VCU118ShellBasicOverlays] {
+  def place(designInput: PCIeDesignInput) = new PCIeVCU118FMCPlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
-class PCIeVCU118EdgeOverlay(val shell: VCU118ShellBasicOverlays, val name: String, params: PCIeOverlayParams)
-  extends PCIeUltraScaleOverlay(XDMAParams(
+class PCIeVCU118EdgePlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: PCIeDesignInput, val shellInput: PCIeShellInput)
+  extends PCIeUltraScalePlacedOverlay(name, designInput, shellInput, XDMAParams(
     name     = "edge_xdma",
     location = "X1Y2",
-    bars     = params.bars,
-    control  = params.ecam,
-    lanes    = 8), params)
+    bars     = designInput.bars,
+    control  = designInput.ecam,
+    lanes    = 8))
 {
   shell { InModuleBody {
     // Work-around incorrectly pre-assigned pins
@@ -400,24 +394,24 @@ class PCIeVCU118EdgeOverlay(val shell: VCU118ShellBasicOverlays, val name: Strin
     bind(IOPin.of(io.lanes.pci_exp_rxn), rxn)
   } }
 }
-object PCIeVCU118EdgeOverlay {
-  implicit object PCIeVCU118FMCMetadata extends HasMetadata[PCIeVCU118EdgeOverlay] {
-    def metadata = OverlayMetadata()
-} }
+class PCIeVCU118EdgeShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: PCIeShellInput)(implicit val valName: ValName)
+  extends PCIeShellPlacer[VCU118ShellBasicOverlays] {
+  def place(designInput: PCIeDesignInput) = new PCIeVCU118EdgePlacedOverlay(shell, valName.name, designInput, shellInput)
+}
 
 abstract class VCU118ShellBasicOverlays()(implicit p: Parameters) extends UltraScaleShell{
-  val sys_clock = Overlay(ClockInputOverlayKey)(new SysClockVCU118Overlay (_, _, _))
-  val ref_clock = Overlay(ClockInputOverlayKey)(new RefClockVCU118Overlay (_, _, _))
-  val led       = Overlay(LEDOverlayKey)       (new LEDVCU118Overlay      (_, _, _))
-  val switch    = Overlay(SwitchOverlayKey)    (new SwitchVCU118Overlay   (_, _, _))
-  val ddr       = Overlay(DDROverlayKey)       (new DDRVCU118Overlay      (_, _, _))
-  val uart      = Overlay(UARTOverlayKey)      (new UARTVCU118Overlay     (_, _, _))
-  val sdio      = Overlay(SDIOOverlayKey)      (new SDIOVCU118Overlay     (_, _, _))
-  val jtag      = Overlay(JTAGDebugOverlayKey) (new JTAGDebugVCU118Overlay(_, _, _))
-  val qsfp1     = Overlay(EthernetOverlayKey)  (new QSFP1VCU118Overlay    (_, _, _))
-  val qsfp2     = Overlay(EthernetOverlayKey)  (new QSFP2VCU118Overlay    (_, _, _))
-  val chiplink  = Overlay(ChipLinkOverlayKey)  (new ChipLinkVCU118Overlay (_, _, _))
-  val spi_flash = Overlay(SPIFlashOverlayKey)  (new SPIFlashVCU118Overlay (_, _, _))
+  val sys_clock = Overlay(ClockInputOverlayKey, new SysClockVCU118ShellPlacer(this, ClockInputShellInput()))
+  val ref_clock = Overlay(ClockInputOverlayKey, new RefClockVCU118ShellPlacer(this, ClockInputShellInput()))
+  val led       = Overlay(LEDOverlayKey, new LEDVCU118ShellPlacer(this, LEDShellInput()))
+  val switch    = Overlay(SwitchOverlayKey, new SwitchVCU118ShellPlacer(this, SwitchShellInput()))
+  val ddr       = Overlay(DDROverlayKey, new DDRVCU118ShellPlacer(this, DDRShellInput()))
+  val uart      = Overlay(UARTOverlayKey, new UARTVCU118ShellPlacer(this, UARTShellInput()))
+  val sdio      = Overlay(SDIOOverlayKey, new SDIOVCU118ShellPlacer(this, SDIOShellInput()))
+  val jtag      = Overlay(JTAGDebugOverlayKey, new JTAGDebugVCU118ShellPlacer(this, JTAGDebugShellInput()))
+  val qsfp1     = Overlay(EthernetOverlayKey, new QSFP1VCU118ShellPlacer(this, EthernetShellInput()))
+  val qsfp2     = Overlay(EthernetOverlayKey, new QSFP2VCU118ShellPlacer(this, EthernetShellInput()))
+  val chiplink  = Overlay(ChipLinkOverlayKey, new ChipLinkVCU118ShellPlacer(this, ChipLinkShellInput()))
+  val spi_flash = Overlay(SPIFlashOverlayKey, new SPIFlashVCU118ShellPlacer(this, SPIFlashShellInput()))
 }
 
 class VCU118Shell()(implicit p: Parameters) extends VCU118ShellBasicOverlays
@@ -426,14 +420,14 @@ class VCU118Shell()(implicit p: Parameters) extends VCU118ShellBasicOverlays
   val pllReset = InModuleBody { Wire(Bool()) }
 
   // Order matters; ddr depends on sys_clock
-  val fmc       = Overlay(PCIeOverlayKey)      (new PCIeVCU118FMCOverlay  (_, _, _))
-  val edge      = Overlay(PCIeOverlayKey)      (new PCIeVCU118EdgeOverlay (_, _, _))
+  val fmc       = Overlay(PCIeOverlayKey, new PCIeVCU118FMCShellPlacer(this, PCIeShellInput()))
+  val edge      = Overlay(PCIeOverlayKey, new PCIeVCU118EdgeShellPlacer(this, PCIeShellInput()))
 
   val topDesign = LazyModule(p(DesignKey)(designParameters))
 
   // Place the sys_clock at the Shell if the user didn't ask for it
   designParameters(ClockInputOverlayKey).foreach { unused =>
-    val source = unused(ClockInputOverlayParams())
+    val source = unused.place(ClockInputDesignInput()).overlayOutput.node
     val sink = ClockSinkNode(Seq(ClockSinkParameters()))
     sink := source
   }
@@ -446,11 +440,19 @@ class VCU118Shell()(implicit p: Parameters) extends VCU118ShellBasicOverlays
     val reset_ibuf = Module(new IBUF)
     reset_ibuf.io.I := reset
 
-    val powerOnReset = PowerOnResetFPGAOnly(sys_clock.get.clock)
+    val sysclk: Clock = sys_clock.get() match {
+      case Some(x: SysClockVCU118PlacedOverlay) => x.clock
+    }
+
+    val powerOnReset: Bool = PowerOnResetFPGAOnly(sysclk)
     sdc.addAsyncPath(Seq(powerOnReset))
 
-    pllReset :=
-      reset_ibuf.io.O || powerOnReset ||
-      chiplink.map(!_.ereset_n).getOrElse(false.B)
+    val ereset: Bool = chiplink.get() match {
+      case Some(x: ChipLinkVCU118PlacedOverlay) => !x.ereset_n
+      case _ => false.B
+    }
+
+    pllReset := (reset_ibuf.io.O || powerOnReset || ereset)
+    val hi = "hi"
   }
 }

--- a/src/main/scala/shell/xilinx/cJTAGDebugOverlay.scala
+++ b/src/main/scala/shell/xilinx/cJTAGDebugOverlay.scala
@@ -6,8 +6,8 @@ import freechips.rocketchip.diplomacy._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.xilinx._
 
-abstract class cJTAGDebugXilinxOverlay(params: cJTAGDebugOverlayParams)
-  extends cJTAGDebugOverlay(params)
+abstract class cJTAGDebugXilinxPlacedOverlay(name: String, di: cJTAGDebugDesignInput, si: cJTAGDebugShellInput)
+  extends cJTAGDebugPlacedOverlay(name, di, si)
 {
   def shell: XilinxShell
 }


### PR DESCRIPTION
New API for shells. A lot of files have changed, but the main file is the Shell.scala. 

Overlays are now created differently, and have changed name to "PlacedOverlays" to clear up confusion. This is different from a "ShellPlacer" which is created to instantiate the placedoverlay and define its .place function. These overlays also now take 2 inputs, a DesignInput, provided by the design itself just like the OverlayParams before, and a ShellInput, which includes metadata that is shell specific. This data can be accessed before the overlay is placed to provide the design power to choose based on information from the shell which overlay to place.