### PR TITLE
add ability for internal reset driver, pullup one pmod for disabledeb…

### DIFF
--- a/src/main/scala/shell/CTSResetOverlay.scala
+++ b/src/main/scala/shell/CTSResetOverlay.scala
@@ -1,0 +1,23 @@
+// See LICENSE for license details.
+package sifive.fpgashells.shell
+
+import chisel3._
+import freechips.rocketchip.config._
+import freechips.rocketchip.diplomacy._
+
+//Core-To-Shell Reset Overlay: No IOs, but passes a Bool into the shell to be orred into the pllReset, allowing core signals to reset the shell
+
+case class CTSResetShellInput()
+case class CTSResetDesignInput(rst: Bool)(implicit val p: Parameters)
+case class CTSResetOverlayOutput()
+case object CTSResetOverlayKey extends Field[Seq[DesignPlacer[CTSResetDesignInput, CTSResetShellInput, CTSResetOverlayOutput]]](Nil)
+trait CTSResetShellPlacer[Shell] extends ShellPlacer[CTSResetDesignInput, CTSResetShellInput, CTSResetOverlayOutput]
+
+abstract class CTSResetPlacedOverlay(
+  val name: String, val di: CTSResetDesignInput, si: CTSResetShellInput)
+    extends PlacedOverlay[CTSResetDesignInput, CTSResetShellInput, CTSResetOverlayOutput]
+{
+  implicit val p = di.p
+
+  def overlayOutput = CTSResetOverlayOutput()
+}


### PR DESCRIPTION
1. Add CTSReset Overlay (Core-to-shell reset) to allow core to pass a signal that automatically gets orred into the pllReset, default it to false

2. Add a pullup to the last pmodB signal so that it can be used for disableDebug signal