### PR TITLE
removing inline tc comment

### DIFF
--- a/xilinx/common/tcl/prologue.tcl
+++ b/xilinx/common/tcl/prologue.tcl
@@ -27,7 +27,7 @@ while {[llength $argv]} {
       set argv [lassign $argv[set argv {}] post_impl_debug_tcl]
     }
     -env-var-srcs {
-      set argv [lassign $argv[set argv {}] env_var_srcs] # See comment below
+      set argv [lassign $argv[set argv {}] env_var_srcs]
     }
     default {
       return -code error [list {unknown option} $flag]


### PR DESCRIPTION
tcl didnt like this, so I am removing it. The comment below it still describes the function though