### PR TITLE
Peripherals shell

### DIFF
--- a/src/main/scala/shell/I2COverlay.scala
+++ b/src/main/scala/shell/I2COverlay.scala
@@ -11,7 +11,7 @@ import freechips.rocketchip.tilelink.TLBusWrapper
 import freechips.rocketchip.interrupts.IntInwardNode
 
 //This should NOT do the device placement, just return the bundlebridge
-case class I2CShellInput()
+case class I2CShellInput(number: Int = 0)
 case class I2CDesignInput(i2cParams: I2CParams, controlBus: TLBusWrapper, intNode: IntInwardNode)(implicit val p: Parameters)
 case class I2COverlayOutput(i2c: TLI2C)
 trait I2CShellPlacer[Shell] extends ShellPlacer[I2CDesignInput, I2CShellInput, I2COverlayOutput]

--- a/src/main/scala/shell/I2COverlay.scala
+++ b/src/main/scala/shell/I2COverlay.scala
@@ -11,7 +11,7 @@ import freechips.rocketchip.tilelink.TLBusWrapper
 import freechips.rocketchip.interrupts.IntInwardNode
 
 //This should NOT do the device placement, just return the bundlebridge
-case class I2CShellInput(number: Int = 0)
+case class I2CShellInput(index: Int = 0)
 case class I2CDesignInput(i2cParams: I2CParams, controlBus: TLBusWrapper, intNode: IntInwardNode)(implicit val p: Parameters)
 case class I2COverlayOutput(i2c: TLI2C)
 trait I2CShellPlacer[Shell] extends ShellPlacer[I2CDesignInput, I2CShellInput, I2COverlayOutput]

--- a/src/main/scala/shell/PWMOverlay.scala
+++ b/src/main/scala/shell/PWMOverlay.scala
@@ -11,7 +11,7 @@ import freechips.rocketchip.tilelink.TLBusWrapper
 import freechips.rocketchip.interrupts.IntInwardNode
 
 //another one that makes the controller... remove this
-case class PWMShellInput(number: Int = 0)
+case class PWMShellInput(index: Int = 0)
 case class PWMDesignInput(pwmParams: PWMParams, controlBus: TLBusWrapper, intNode: IntInwardNode)(implicit val p: Parameters)
 case class PWMOverlayOutput(pwm: TLPWM)
 case object PWMOverlayKey extends Field[Seq[DesignPlacer[PWMDesignInput, PWMShellInput, PWMOverlayOutput]]](Nil)

--- a/src/main/scala/shell/PWMOverlay.scala
+++ b/src/main/scala/shell/PWMOverlay.scala
@@ -11,7 +11,7 @@ import freechips.rocketchip.tilelink.TLBusWrapper
 import freechips.rocketchip.interrupts.IntInwardNode
 
 //another one that makes the controller... remove this
-case class PWMShellInput()
+case class PWMShellInput(number: Int = 0)
 case class PWMDesignInput(pwmParams: PWMParams, controlBus: TLBusWrapper, intNode: IntInwardNode)(implicit val p: Parameters)
 case class PWMOverlayOutput(pwm: TLPWM)
 case object PWMOverlayKey extends Field[Seq[DesignPlacer[PWMDesignInput, PWMShellInput, PWMOverlayOutput]]](Nil)

--- a/src/main/scala/shell/SPIFlashOverlay.scala
+++ b/src/main/scala/shell/SPIFlashOverlay.scala
@@ -10,7 +10,7 @@ import freechips.rocketchip.interrupts.IntInwardNode
 import chisel3.experimental.Analog
 
 //This one does controller also
-case class SPIFlashShellInput()
+case class SPIFlashShellInput(number: Int = 0)
 case class SPIFlashDesignInput(spiFlashParam: SPIFlashParams, controlBus: TLBusWrapper, memBus: TLBusWrapper, intNode: IntInwardNode)(implicit val p: Parameters)
 case class SPIFlashOverlayOutput(spiflash: TLSPIFlash)
 case object SPIFlashOverlayKey extends Field[Seq[DesignPlacer[SPIFlashDesignInput, SPIFlashShellInput, SPIFlashOverlayOutput]]](Nil)

--- a/src/main/scala/shell/SPIFlashOverlay.scala
+++ b/src/main/scala/shell/SPIFlashOverlay.scala
@@ -10,7 +10,7 @@ import freechips.rocketchip.interrupts.IntInwardNode
 import chisel3.experimental.Analog
 
 //This one does controller also
-case class SPIFlashShellInput(number: Int = 0)
+case class SPIFlashShellInput(index: Int = 0)
 case class SPIFlashDesignInput(spiFlashParam: SPIFlashParams, controlBus: TLBusWrapper, memBus: TLBusWrapper, intNode: IntInwardNode)(implicit val p: Parameters)
 case class SPIFlashOverlayOutput(spiflash: TLSPIFlash)
 case object SPIFlashOverlayKey extends Field[Seq[DesignPlacer[SPIFlashDesignInput, SPIFlashShellInput, SPIFlashOverlayOutput]]](Nil)

--- a/src/main/scala/shell/UARTOverlay.scala
+++ b/src/main/scala/shell/UARTOverlay.scala
@@ -12,7 +12,7 @@ import freechips.rocketchip.interrupts.IntInwardNode
 
 //dont make the controller here
 //move flowcontrol to shell input?? 
-case class UARTShellInput()
+case class UARTShellInput(number: Int = 0)
 case class UARTDesignInput(uartParams: UARTParams, divInit: Int, controlBus: TLBusWrapper, intNode: IntInwardNode)(implicit val p: Parameters)
 case class UARTOverlayOutput(uart: TLUART)
 case object UARTOverlayKey extends Field[Seq[DesignPlacer[UARTDesignInput, UARTShellInput, UARTOverlayOutput]]](Nil)

--- a/src/main/scala/shell/UARTOverlay.scala
+++ b/src/main/scala/shell/UARTOverlay.scala
@@ -12,7 +12,7 @@ import freechips.rocketchip.interrupts.IntInwardNode
 
 //dont make the controller here
 //move flowcontrol to shell input?? 
-case class UARTShellInput(number: Int = 0)
+case class UARTShellInput(index: Int = 0)
 case class UARTDesignInput(uartParams: UARTParams, divInit: Int, controlBus: TLBusWrapper, intNode: IntInwardNode)(implicit val p: Parameters)
 case class UARTOverlayOutput(uart: TLUART)
 case object UARTOverlayKey extends Field[Seq[DesignPlacer[UARTDesignInput, UARTShellInput, UARTOverlayOutput]]](Nil)

--- a/src/main/scala/shell/xilinx/PWMOverlay.scala
+++ b/src/main/scala/shell/xilinx/PWMOverlay.scala
@@ -13,7 +13,7 @@ abstract class PWMXilinxPlacedOverlay(name: String, di: PWMDesignInput, si: PWMS
 
   shell { InModuleBody {
     tlpwmSink.bundle.gpio.zip(io.pwm_gpio).foreach { case(design_pwm, io_pwm) =>
-      io_pwm := design_pwm 
+      UIntToAnalog(design_pwm, io_pwm, true.B)
     }
   } }
 }

--- a/src/main/scala/shell/xilinx/PeripheralsVC707Shell.scala
+++ b/src/main/scala/shell/xilinx/PeripheralsVC707Shell.scala
@@ -21,10 +21,10 @@ class UARTPeripheralVC707PlacedOverlay(val shell: VC707Shell, name: String, val 
 {
     shell { InModuleBody {
     val uartLocations = List(List("AT32", "AR34", "AU33", "AU36"), List("V34", "T35", "V33", "U34")) //uart0 - USB, uart1 - FMC 105 debug card J20 p1-rx p2-tx p3-ctsn p4-rtsn
-    val packagePinsWithPackageIOs = Seq((uartLocations(shellInput.number)(0), IOPin(io.ctsn.get)),
-                                        (uartLocations(shellInput.number)(1), IOPin(io.rtsn.get)),
-                                        (uartLocations(shellInput.number)(2), IOPin(io.rxd)),
-                                        (uartLocations(shellInput.number)(3), IOPin(io.txd)))
+    val packagePinsWithPackageIOs = Seq((uartLocations(shellInput.index)(0), IOPin(io.ctsn.get)),
+                                        (uartLocations(shellInput.index)(1), IOPin(io.rtsn.get)),
+                                        (uartLocations(shellInput.index)(2), IOPin(io.rxd)),
+                                        (uartLocations(shellInput.index)(3), IOPin(io.txd)))
 
     packagePinsWithPackageIOs foreach { case (pin, io) => {
       shell.xdc.addPackagePin(io, pin)
@@ -45,8 +45,8 @@ class I2CPeripheralVC707PlacedOverlay(val shell: VC707Shell, name: String, val d
 {
     shell { InModuleBody {
     val i2cLocations = List(List("AJ38", "U32"), List("AK38", "U33")) //i2c0: J1 p37-scl p38-sda i2c1: J2 p39-scl p40-sda
-    val packagePinsWithPackageIOs = Seq((i2cLocations(shellInput.number)(0), IOPin(io.scl)),
-                                        (i2cLocations(shellInput.number)(1), IOPin(io.sda)))
+    val packagePinsWithPackageIOs = Seq((i2cLocations(shellInput.index)(0), IOPin(io.scl)),
+                                        (i2cLocations(shellInput.index)(1), IOPin(io.sda)))
 
     packagePinsWithPackageIOs foreach { case (pin, io) => {
       shell.xdc.addPackagePin(io, pin)
@@ -67,12 +67,12 @@ class QSPIPeripheralVC707PlacedOverlay(val shell: VC707Shell, name: String, val 
 {
     shell { InModuleBody {
     val qspiLocations = List(List("AD40", "AB41", "AD41", "AB42", "AF41", "Y42"), List("AG41", "AA42", "AK39", "Y39", "AL39", "AA39")) //J1 pins 1-6 and 7-12 (sck, cs, dq0-3)
-    val packagePinsWithPackageIOs = Seq((qspiLocations(shellInput.number)(0), IOPin(io.qspi_sck)),
-                                        (qspiLocations(shellInput.number)(1), IOPin(io.qspi_cs)),
-                                        (qspiLocations(shellInput.number)(2), IOPin(io.qspi_dq(0))),
-                                        (qspiLocations(shellInput.number)(3), IOPin(io.qspi_dq(1))),
-                                        (qspiLocations(shellInput.number)(4), IOPin(io.qspi_dq(2))),
-                                        (qspiLocations(shellInput.number)(5), IOPin(io.qspi_dq(3))))
+    val packagePinsWithPackageIOs = Seq((qspiLocations(shellInput.index)(0), IOPin(io.qspi_sck)),
+                                        (qspiLocations(shellInput.index)(1), IOPin(io.qspi_cs)),
+                                        (qspiLocations(shellInput.index)(2), IOPin(io.qspi_dq(0))),
+                                        (qspiLocations(shellInput.index)(3), IOPin(io.qspi_dq(1))),
+                                        (qspiLocations(shellInput.index)(4), IOPin(io.qspi_dq(2))),
+                                        (qspiLocations(shellInput.index)(5), IOPin(io.qspi_dq(3))))
 
     packagePinsWithPackageIOs foreach { case (pin, io) => {
       shell.xdc.addPackagePin(io, pin)
@@ -139,10 +139,10 @@ class GPIOPeripheralVC707ShellPlacer(val shell: VC707Shell, val shellInput: GPIO
 class PeripheralVC707Shell(implicit p: Parameters) extends VC707Shell {
 
   val gpio           = Overlay(GPIOOverlayKey,       new GPIOPeripheralVC707ShellPlacer(this, GPIOShellInput()))
-  val uart  = Seq.tabulate(2) { i => Overlay(UARTOverlayKey, new UARTPeripheralVC707ShellPlacer(this, UARTShellInput(number = i))(valName = ValName(s"uart$i"))) }
-  val qspi      = Seq.tabulate(2) { i => Overlay(SPIFlashOverlayKey, new QSPIPeripheralVC707ShellPlacer(this, SPIFlashShellInput(number = i))(valName = ValName(s"qspi$i"))) }
-  val pwm       = Seq.tabulate(1) { i => Overlay(PWMOverlayKey, new PWMPeripheralVC707ShellPlacer(this, PWMShellInput(number = i))(valName = ValName(s"pwm$i"))) }
-  val i2c       = Seq.tabulate(2) { i => Overlay(I2COverlayKey, new I2CPeripheralVC707ShellPlacer(this, I2CShellInput(number = i))(valName = ValName(s"i2c$i"))) }
+  val uart  = Seq.tabulate(2) { i => Overlay(UARTOverlayKey, new UARTPeripheralVC707ShellPlacer(this, UARTShellInput(index = i))(valName = ValName(s"uart$i"))) }
+  val qspi      = Seq.tabulate(2) { i => Overlay(SPIFlashOverlayKey, new QSPIPeripheralVC707ShellPlacer(this, SPIFlashShellInput(index = i))(valName = ValName(s"qspi$i"))) }
+  val pwm       = Seq.tabulate(1) { i => Overlay(PWMOverlayKey, new PWMPeripheralVC707ShellPlacer(this, PWMShellInput(index = i))(valName = ValName(s"pwm$i"))) }
+  val i2c       = Seq.tabulate(2) { i => Overlay(I2COverlayKey, new I2CPeripheralVC707ShellPlacer(this, I2CShellInput(index = i))(valName = ValName(s"i2c$i"))) }
 
   val topDesign = LazyModule(p(DesignKey)(designParameters))
 

--- a/src/main/scala/shell/xilinx/PeripheralsVC707Shell.scala
+++ b/src/main/scala/shell/xilinx/PeripheralsVC707Shell.scala
@@ -1,0 +1,166 @@
+// See LICENSE for license details.
+package sifive.fpgashells.shell.xilinx
+
+import chisel3._
+import chisel3.experimental._
+
+import freechips.rocketchip.config._
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.tilelink._
+import freechips.rocketchip.util._
+
+import sifive.fpgashells.clocks._
+import sifive.fpgashells.shell._
+import sifive.fpgashells.ip.xilinx._
+
+import sifive.blocks.devices.gpio._
+import sifive.blocks.devices.pinctrl._
+
+import sifive.enterprise.firrtl._
+
+class UARTPeripheralVC707PlacedOverlay(val shell: VC707Shell, name: String, val designInput: UARTDesignInput, val shellInput: UARTShellInput)
+  extends UARTXilinxPlacedOverlay(name, designInput, shellInput, true)
+{
+    shell { InModuleBody {
+    val uartLocations = List(List("AT32", "AR34", "AU33", "AU36"), List("FILL", "THIS", "IN", "PINS"))
+    val packagePinsWithPackageIOs = Seq((uartLocations(shellInput.number)(0), IOPin(io.ctsn.get)),
+                                        (uartLocations(shellInput.number)(1), IOPin(io.rtsn.get)),
+                                        (uartLocations(shellInput.number)(2), IOPin(io.rxd)),
+                                        (uartLocations(shellInput.number)(3), IOPin(io.txd)))
+
+    packagePinsWithPackageIOs foreach { case (pin, io) => {
+      shell.xdc.addPackagePin(io, pin)
+      shell.xdc.addIOStandard(io, "LVCMOS18")
+      shell.xdc.addIOB(io)
+    } }
+  } }
+}
+
+class UARTPeripheralVC707ShellPlacer(val shell: VC707Shell, val shellInput: UARTShellInput)(implicit val valName: ValName)
+  extends UARTShellPlacer[VC707Shell]
+{
+  def place(designInput: UARTDesignInput) = new UARTPeripheralVC707PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+
+class I2CPeripheralVC707PlacedOverlay(val shell: VC707Shell, name: String, val designInput: I2CDesignInput, val shellInput: I2CShellInput)
+  extends I2CXilinxPlacedOverlay(name, designInput, shellInput)
+{
+    shell { InModuleBody {
+    val i2cLocations = List(List("A", "B"), List("FILL", "IN"))
+    val packagePinsWithPackageIOs = Seq((i2cLocations(shellInput.number)(0), IOPin(io.scl)),
+                                        (i2cLocations(shellInput.number)(1), IOPin(io.sda)))
+
+    packagePinsWithPackageIOs foreach { case (pin, io) => {
+      shell.xdc.addPackagePin(io, pin)
+      shell.xdc.addIOStandard(io, "LVCMOS18")
+      shell.xdc.addIOB(io)
+    } }
+  } }
+}
+
+class I2CPeripheralVC707ShellPlacer(val shell: VC707Shell, val shellInput: I2CShellInput)(implicit val valName: ValName)
+  extends I2CShellPlacer[VC707Shell]
+{
+  def place(designInput: I2CDesignInput) = new I2CPeripheralVC707PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+
+class QSPIPeripheralVC707PlacedOverlay(val shell: VC707Shell, name: String, val designInput: SPIFlashDesignInput, val shellInput: SPIFlashShellInput)
+  extends SPIFlashXilinxPlacedOverlay(name, designInput, shellInput)
+{
+    shell { InModuleBody {
+    val qspiLocations = List(List("A", "B", "C", "D", "E", "F"), List("FILL", "THIS", "IN", "WITH", "PINS", "LATER"))
+    val packagePinsWithPackageIOs = Seq((qspiLocations(shellInput.number)(0), IOPin(io.qspi_sck)),
+                                        (qspiLocations(shellInput.number)(1), IOPin(io.qspi_cs)),
+                                        (qspiLocations(shellInput.number)(2), IOPin(io.qspi_dq(0))),
+                                        (qspiLocations(shellInput.number)(3), IOPin(io.qspi_dq(1))),
+                                        (qspiLocations(shellInput.number)(4), IOPin(io.qspi_dq(2))),
+                                        (qspiLocations(shellInput.number)(5), IOPin(io.qspi_dq(3))))
+
+    packagePinsWithPackageIOs foreach { case (pin, io) => {
+      shell.xdc.addPackagePin(io, pin)
+      shell.xdc.addIOStandard(io, "LVCMOS18")
+      shell.xdc.addIOB(io)
+    } }
+    packagePinsWithPackageIOs drop 1 foreach { case (pin, io) => {
+      shell.xdc.addPullup(io)
+    } }
+  } }
+}
+
+class QSPIPeripheralVC707ShellPlacer(val shell: VC707Shell, val shellInput: SPIFlashShellInput)(implicit val valName: ValName)
+  extends SPIFlashShellPlacer[VC707Shell]
+{
+  def place(designInput: SPIFlashDesignInput) = new QSPIPeripheralVC707PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+
+class PWMPeripheralVC707PlacedOverlay(val shell: VC707Shell, name: String, val designInput: PWMDesignInput, val shellInput: PWMShellInput)
+  extends PWMXilinxPlacedOverlay(name, designInput, shellInput)
+{
+    shell { InModuleBody {
+    val packagePinsWithPackageIOs = Seq(("A", IOPin(io.pwm_gpio(0))),
+                                        ("B", IOPin(io.pwm_gpio(1))),
+                                        ("C", IOPin(io.pwm_gpio(2))),
+                                        ("D", IOPin(io.pwm_gpio(3))))
+
+    packagePinsWithPackageIOs foreach { case (pin, io) => {
+      shell.xdc.addPackagePin(io, pin)
+      shell.xdc.addIOStandard(io, "LVCMOS18")
+      shell.xdc.addIOB(io)
+    } }
+  } }
+}
+
+class PWMPeripheralVC707ShellPlacer(val shell: VC707Shell, val shellInput: PWMShellInput)(implicit val valName: ValName)
+  extends PWMShellPlacer[VC707Shell] {
+  def place(designInput: PWMDesignInput) = new PWMPeripheralVC707PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+
+class GPIOPeripheralVC707PlacedOverlay(val shell: VC707Shell, name: String, val designInput: GPIODesignInput, val shellInput: GPIOShellInput)
+  extends GPIOXilinxPlacedOverlay(name, designInput, shellInput)
+{
+    shell { InModuleBody {
+    val gpioLocations = List("A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M")
+    val iosWithLocs = io.gpio.zip(gpioLocations)
+    val packagePinsWithPackageIOs = iosWithLocs.map { case (io, pin) => (pin, IOPin(io)) }
+    println(packagePinsWithPackageIOs)
+
+    packagePinsWithPackageIOs foreach { case (pin, io) => {
+      shell.xdc.addPackagePin(io, pin)
+      shell.xdc.addIOStandard(io, "LVCMOS18")
+      shell.xdc.addIOB(io)
+    } }
+  } }
+}
+
+class GPIOPeripheralVC707ShellPlacer(val shell: VC707Shell, val shellInput: GPIOShellInput)(implicit val valName: ValName)
+  extends GPIOShellPlacer[VC707Shell] {
+
+  def place(designInput: GPIODesignInput) = new GPIOPeripheralVC707PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+
+class PeripheralVC707Shell(implicit p: Parameters) extends VC707Shell {
+
+  val gpio           = Overlay(GPIOOverlayKey,       new GPIOPeripheralVC707ShellPlacer(this, GPIOShellInput()))
+  val uart  = Seq.tabulate(2) { i => Overlay(UARTOverlayKey, new UARTPeripheralVC707ShellPlacer(this, UARTShellInput(number = i))(valName = ValName(s"uart$i"))) }
+  val qspi      = Seq.tabulate(2) { i => Overlay(SPIFlashOverlayKey, new QSPIPeripheralVC707ShellPlacer(this, SPIFlashShellInput(number = i))(valName = ValName(s"qspi$i"))) }
+  val pwm       = Seq.tabulate(1) { i => Overlay(PWMOverlayKey, new PWMPeripheralVC707ShellPlacer(this, PWMShellInput(number = i))(valName = ValName(s"pwm$i"))) }
+  val i2c       = Seq.tabulate(2) { i => Overlay(I2COverlayKey, new I2CPeripheralVC707ShellPlacer(this, I2CShellInput(number = i))(valName = ValName(s"i2c$i"))) }
+
+  val topDesign = LazyModule(p(DesignKey)(designParameters))
+
+  p(ClockInputOverlayKey).foreach(_.place(ClockInputDesignInput()))
+
+  override lazy val module = new LazyRawModuleImp(this) {
+    topDesign.module.asInstanceOf[LazyRawModuleImp with MarkDUT].markDUT()
+
+    val reset = IO(Input(Bool()))
+    val clock = IO(Input(Clock()))
+
+    val por_clock = sys_clock.get.get.asInstanceOf[SysClockVC707PlacedOverlay].clock
+    val powerOnReset = PowerOnResetFPGAOnly(por_clock)
+
+    pllReset :=
+      reset || powerOnReset
+
+  }
+}

--- a/src/main/scala/shell/xilinx/VC707NewShell.scala
+++ b/src/main/scala/shell/xilinx/VC707NewShell.scala
@@ -309,6 +309,7 @@ class VC707BaseShell()(implicit p: Parameters) extends VC707Shell
 
 class VC707PCIeShell()(implicit p: Parameters) extends VC707Shell
 {
+  val uart      = Seq.tabulate(1)(i => Overlay(UARTOverlayKey, new UARTVC707ShellPlacer(this, UARTShellInput(index = 0))))
   val pcie      = Overlay(PCIeOverlayKey, new PCIeVC707ShellPlacer(this, PCIeShellInput()))
   val topDesign = LazyModule(p(DesignKey)(designParameters))
 

--- a/src/main/scala/shell/xilinx/VC707NewShell.scala
+++ b/src/main/scala/shell/xilinx/VC707NewShell.scala
@@ -279,7 +279,7 @@ abstract class VC707Shell()(implicit p: Parameters) extends Series7Shell
 
 class VC707BaseShell()(implicit p: Parameters) extends VC707Shell
 {
-  val uart      = Seq.tabulate(1)(i => Overlay(UARTOverlayKey, new UARTVC707ShellPlacer(this, UARTShellInput())))
+  val uart      = Seq.tabulate(1)(i => Overlay(UARTOverlayKey, new UARTVC707ShellPlacer(this, UARTShellInput(index = 0))))
   val topDesign = LazyModule(p(DesignKey)(designParameters))
 
   // Place the sys_clock at the Shell if the user didn't ask for it

--- a/src/main/scala/shell/xilinx/VC707NewShell.scala
+++ b/src/main/scala/shell/xilinx/VC707NewShell.scala
@@ -273,13 +273,13 @@ abstract class VC707Shell()(implicit p: Parameters) extends Series7Shell
   val button    = Seq.tabulate(5)(i => Overlay(ButtonOverlayKey, new ButtonVC707ShellPlacer(this, ButtonShellInput(number = i))(valName = ValName(s"button_$i"))))
   val chiplink  = Overlay(ChipLinkOverlayKey, new ChipLinkVC707ShellPlacer(this, ChipLinkShellInput()))
   val ddr       = Overlay(DDROverlayKey, new DDRVC707ShellPlacer(this, DDRShellInput()))
-  val uart      = Overlay(UARTOverlayKey, new UARTVC707ShellPlacer(this, UARTShellInput()))
   val sdio      = Overlay(SDIOOverlayKey, new SDIOVC707ShellPlacer(this, SDIOShellInput()))
   val jtag      = Overlay(JTAGDebugOverlayKey, new JTAGDebugVC707ShellPlacer(this, JTAGDebugShellInput()))
 }
 
 class VC707BaseShell()(implicit p: Parameters) extends VC707Shell
 {
+  val uart      = Seq.tabulate(1)(i => Overlay(UARTOverlayKey, new UARTVC707ShellPlacer(this, UARTShellInput())))
   val topDesign = LazyModule(p(DesignKey)(designParameters))
 
   // Place the sys_clock at the Shell if the user didn't ask for it

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "5ecd49672281491ca4be2d8446377468bfb1e81b",
+        "commit": "50b9d6ffdfbff683fa25045d7f1ef3585a34f2dc",
         "name": "api-generator-sifive",
         "source": "git@github.com:sifive/api-generator-sifive.git"
     },

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "056feb97299585a944e4cb45a22b14bdec45a231",
+        "commit": "5ecd49672281491ca4be2d8446377468bfb1e81b",
         "name": "api-generator-sifive",
         "source": "git@github.com:sifive/api-generator-sifive.git"
     },

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "50b9d6ffdfbff683fa25045d7f1ef3585a34f2dc",
+        "commit": "056feb97299585a944e4cb45a22b14bdec45a231",
         "name": "api-generator-sifive",
         "source": "git@github.com:sifive/api-generator-sifive.git"
     },

--- a/xilinx/common/vsrc/AnalogToUInt.v
+++ b/xilinx/common/vsrc/AnalogToUInt.v
@@ -1,0 +1,12 @@
+// See LICENSE for license details.
+
+module AnalogToUInt (a, b);
+
+   parameter WIDTH = 1;
+
+   inout [WIDTH-1:0]  a;
+   output [WIDTH-1:0] b;
+
+   assign b = a;
+
+endmodule

--- a/xilinx/common/vsrc/UIntToAnalog.v
+++ b/xilinx/common/vsrc/UIntToAnalog.v
@@ -1,0 +1,17 @@
+// See LICENSE for license details.
+
+module UIntToAnalog (a, b, b_en);
+
+   parameter WIDTH = 1;
+
+   inout [WIDTH-1:0] a;
+   input [WIDTH-1:0] b;
+   input             b_en;
+
+   wire [31:0]       z32;
+   
+   assign z32 = 32'hZZZZZZZZ;
+
+   assign a = b_en ? b : z32[WIDTH-1:0];
+
+endmodule


### PR DESCRIPTION
Make a VC707 shell with peripheral overlays, move UART up a level so that it is not part of the lowest level shell (since it is a peripheral), but still is included in builds using VC707BaseShell