### PR TITLE
Restore jtag/cjtag srst_n input so external probes can reset the system

### DIFF
--- a/src/main/scala/shell/JTAGDebugOverlay.scala
+++ b/src/main/scala/shell/JTAGDebugOverlay.scala
@@ -23,6 +23,7 @@ class ShellJTAGIO extends Bundle {
   val jtag_TMS = Analog(1.W)
   val jtag_TDI = Analog(1.W)
   val jtag_TDO = Analog(1.W)
+  val srst_n   = Analog(1.W)
 }
 
 // TODO: Fix interaction of BundleBridge/Flipped to get rid of this Bundle
@@ -31,6 +32,7 @@ class FlippedJTAGIO extends Bundle {
   val TMS = Input(Bool())
   val TDI = Input(Bool())
   val TDO = Output(new Tristate())
+  val srst_n = Input(Bool())
 }
 
 abstract class JTAGDebugPlacedOverlay(

--- a/src/main/scala/shell/cJTAGDebugOverlay.scala
+++ b/src/main/scala/shell/cJTAGDebugOverlay.scala
@@ -33,6 +33,7 @@ class FPGAcJTAGIO extends Bundle {
 class FPGAcJTAGSignals extends Bundle {
   val tckc_pin = Input(Clock())
   val tmsc_pin = new BasePin()
+  val srst_n   = Input(Bool())
 }
 
 abstract class cJTAGDebugPlacedOverlay(
@@ -51,5 +52,6 @@ abstract class cJTAGDebugPlacedOverlay(
     cjtagDebugSink.bundle.tckc_pin := IOBUF(io.cjtag_TCKC).asClock
     IOBUF(io.cjtag_TMSC, cjtagDebugSink.bundle.tmsc_pin)
     KEEPER(io.cjtag_TMSC)
+    cjtagDebugSink.bundle.srst_n := IOBUF(io.srst_n)
   } }
 }

--- a/src/main/scala/shell/xilinx/Arty100TShell.scala
+++ b/src/main/scala/shell/xilinx/Arty100TShell.scala
@@ -184,7 +184,8 @@ class JTAGDebugArtyPlacedOverlay(val shell: Arty100TShellBasicOverlays, name: St
     val packagePinsWithPackageIOs = Seq(("F4", IOPin(io.jtag_TCK)),  //pin JD-3
       ("D2", IOPin(io.jtag_TMS)),  //pin JD-8
       ("E2", IOPin(io.jtag_TDI)),  //pin JD-7
-      ("D4", IOPin(io.jtag_TDO)))  //pin JD-1
+      ("D4", IOPin(io.jtag_TDO)),  //pin JD-1
+      ("H2", IOPin(io.srst_n)))
 
     packagePinsWithPackageIOs foreach { case (pin, io) => {
       shell.xdc.addPackagePin(io, pin)

--- a/src/main/scala/shell/xilinx/JTAGDebugOverlay.scala
+++ b/src/main/scala/shell/xilinx/JTAGDebugOverlay.scala
@@ -16,5 +16,6 @@ abstract class JTAGDebugXilinxPlacedOverlay(name: String, di: JTAGDebugDesignInp
     jtagDebugSink.bundle.TMS := AnalogToUInt(io.jtag_TMS)
     jtagDebugSink.bundle.TDI := AnalogToUInt(io.jtag_TDI)
     UIntToAnalog(jtagDebugSink.bundle.TDO.data,io.jtag_TDO,jtagDebugSink.bundle.TDO.driven)
+    jtagDebugSink.bundle.srst_n := AnalogToUInt(io.srst_n)
   } }
 }


### PR DESCRIPTION
The srst_n input is an input signal with a pullup.  An external probe can drive this low to request a system reset.
