### PR TITLE
remove spi flash

### DIFF
--- a/src/main/scala/shell/xilinx/VCU118NewShell.scala
+++ b/src/main/scala/shell/xilinx/VCU118NewShell.scala
@@ -406,7 +406,8 @@ abstract class VCU118ShellBasicOverlays()(implicit p: Parameters) extends UltraS
   val qsfp1     = Overlay(EthernetOverlayKey, new QSFP1VCU118ShellPlacer(this, EthernetShellInput()))
   val qsfp2     = Overlay(EthernetOverlayKey, new QSFP2VCU118ShellPlacer(this, EthernetShellInput()))
   val chiplink  = Overlay(ChipLinkOverlayKey, new ChipLinkVCU118ShellPlacer(this, ChipLinkShellInput()))
-  val spi_flash = Overlay(SPIFlashOverlayKey, new SPIFlashVCU118ShellPlacer(this, SPIFlashShellInput()))
+  //val spi_flash = Overlay(SPIFlashOverlayKey, new SPIFlashVCU118ShellPlacer(this, SPIFlashShellInput()))
+  //SPI Flash not functional
 }
 
 class VCU118Shell()(implicit p: Parameters) extends VCU118ShellBasicOverlays


### PR DESCRIPTION
VCU118 spirit flash requires startupe3 to operate post programming – not yet onboarded