### PR TITLE
Vcu118 peripheral shell

### DIFF
--- a/src/main/scala/ip/xilinx/Unisim.scala
+++ b/src/main/scala/ip/xilinx/Unisim.scala
@@ -118,6 +118,39 @@ class IBUFDS_GTE4(
     val I     = Clock(INPUT)
     val IB    = Clock(INPUT)
   })
+
+}
+/** STARTUPE3 -- Primitive block to enable application communication with flash device on vcu118. */
+
+class STARTUPE3(
+  PROG_USR : Boolean = false,
+  SIM_CCLK_FREQ : Double = 0
+) 
+extends BlackBox(
+  Map(
+    "PROG_USR" -> booleanToVerilogStringParam(PROG_USR),
+    "SIM_CCLK_FREQ" ->  DoubleParam(SIM_CCLK_FREQ)
+  )
+) {
+  val io = IO(new Bundle {
+    val CFGCLK = Output(Clock())
+    val CFGMCLK = Output(Clock())
+    val DI = Output(UInt(4.W))
+    val EOS = Output(Bool())
+    val PREQ = Output(Bool())
+    val DO = Input(UInt(4.W))
+    val DTS = Input(UInt(4.W))
+    val FCSBO = Input(Bool())
+    val FCSBTS = Input(Bool())
+    val GSR = Input(Bool())
+    val GTS = Input(Bool())
+    val KEYCLEARB = Input(Bool())
+    val PACK = Input(Bool())
+    val USRCCLKO = Input(Clock())
+    val USRCCLKTS = Input(Bool())
+    val USRDONEO = Input(Bool())
+    val USRDONETS = Input(Bool())
+  })
 }
 
 /** IDDR - 7 Series SelectIO DDR flop */

--- a/src/main/scala/shell/PMODOverlay.scala
+++ b/src/main/scala/shell/PMODOverlay.scala
@@ -1,0 +1,38 @@
+// See LICENSE for license details.
+package sifive.fpgashells.shell
+
+import chisel3._
+import freechips.rocketchip.config._
+import freechips.rocketchip.diplomacy._
+import sifive.blocks.devices.gpio._
+import freechips.rocketchip.tilelink.TLBusWrapper
+import freechips.rocketchip.interrupts.IntInwardNode
+import chisel3.experimental.Analog
+
+case class PMODShellInput(index: Int)
+case class PMODDesignInput()(implicit val p: Parameters)
+case class PMODOverlayOutput(pin: ModuleValue[PMODPortIO])
+case object PMODOverlayKey extends Field[Seq[DesignPlacer[PMODDesignInput, PMODShellInput, PMODOverlayOutput]]](Nil)
+trait PMODShellPlacer[Shell] extends ShellPlacer[PMODDesignInput, PMODShellInput, PMODOverlayOutput]
+
+class PMODPortIO extends Bundle {
+  val pins = Vec(8, Analog(1.W))
+}
+
+abstract class PMODPlacedOverlay(
+  val name: String, val di: PMODDesignInput, val si: PMODShellInput)
+    extends IOPlacedOverlay[PMODPortIO, PMODDesignInput, PMODShellInput, PMODOverlayOutput]
+{
+  implicit val p = di.p
+
+  def ioFactory = new PMODPortIO
+
+  val pinSource = BundleBridgeSource(() => new PMODPortIO)
+  val pinSink = shell { pinSource.makeSink }
+
+  def overlayOutput = PMODOverlayOutput(pin = InModuleBody { pinSource.bundle } )
+
+  shell { InModuleBody {
+    io <> pinSink.bundle
+  }}
+}

--- a/src/main/scala/shell/SPIFlashOverlay.scala
+++ b/src/main/scala/shell/SPIFlashOverlay.scala
@@ -13,7 +13,7 @@ import freechips.rocketchip.diplomaticobjectmodel.logicaltree.LogicalTreeNode
 import sifive.blocks.devices.spi._
 
 //This one does controller also
-case class SPIFlashShellInput(index: Int = 0)
+case class SPIFlashShellInput(index: Int = 0, vcu118SU: Boolean = false)
 case class SPIFlashDesignInput(node: BundleBridgeSource[SPIPortIO])(implicit val p: Parameters)
 case class SPIFlashOverlayOutput()
 case object SPIFlashOverlayKey extends Field[Seq[DesignPlacer[SPIFlashDesignInput, SPIFlashShellInput, SPIFlashOverlayOutput]]](Nil)

--- a/src/main/scala/shell/xilinx/PMODOverlay.scala
+++ b/src/main/scala/shell/xilinx/PMODOverlay.scala
@@ -1,0 +1,27 @@
+// See LICENSE for license details.
+package sifive.fpgashells.shell.xilinx
+
+import chisel3._
+import freechips.rocketchip.diplomacy._
+import sifive.fpgashells.shell._
+import sifive.fpgashells.ip.xilinx._
+
+abstract class PMODXilinxPlacedOverlay(name: String, di: PMODDesignInput, si: PMODShellInput, boardPin: Seq[String] = Seq(), packagePin: Seq[String] = Seq(), ioStandard: String = "LVCMOS33")
+  extends PMODPlacedOverlay(name, di, si)
+{
+  def shell: XilinxShell
+
+  shell { InModuleBody {
+    require((boardPin.isEmpty || packagePin.isEmpty), "can't provide both boardpin and packagepin, this is ambiguous")
+    val cutAt = boardPin.length
+    val ios = IOPin.of(io)
+    val boardIO = ios.take(cutAt)
+    val packageIO = ios.drop(cutAt)
+
+    (boardPin   zip boardIO)   foreach { case (pin, io) => shell.xdc.addBoardPin  (io, pin) }
+    (packagePin zip packageIO) foreach { case (pin, io) =>
+      shell.xdc.addPackagePin(io, pin)
+      shell.xdc.addIOStandard(io, ioStandard)
+    }
+  } }
+}

--- a/src/main/scala/shell/xilinx/PeripheralsVCU118Shell.scala
+++ b/src/main/scala/shell/xilinx/PeripheralsVCU118Shell.scala
@@ -1,0 +1,131 @@
+// See LICENSE for license details.
+package sifive.fpgashells.shell.xilinx
+
+import chisel3._
+import chisel3.experimental.{attach, Analog, IO}
+import freechips.rocketchip.config._
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.tilelink._
+import freechips.rocketchip.util.SyncResetSynchronizerShiftReg
+import sifive.fpgashells.clocks._
+import sifive.fpgashells.shell._
+import sifive.fpgashells.ip.xilinx._
+import sifive.blocks.devices.chiplink._
+import sifive.fpgashells.devices.xilinx.xilinxvcu118mig._
+import sifive.fpgashells.devices.xilinx.xdma._
+import sifive.fpgashells.ip.xilinx.xxv_ethernet._
+
+/*
+class SPIFlashVCUV18PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: SPIFlashDesignInput, val shellInput: SPIFlashShellInput)
+  extends SPIFlashXilinxPlacedOverlay(name, designInput, shellInput)
+{
+
+  shell { InModuleBody { 
+    /*val packagePinsWithPackageIOs = Seq(("AF13", IOPin(io.qspi_sck)),
+      ("AJ11", IOPin(io.qspi_cs)),
+      ("AP11", IOPin(io.qspi_dq(0))),
+      ("AN11", IOPin(io.qspi_dq(1))),
+      ("AM11", IOPin(io.qspi_dq(2))),
+      ("AL11", IOPin(io.qspi_dq(3))))
+
+    packagePinsWithPackageIOs foreach { case (pin, io) => {
+      shell.xdc.addPackagePin(io, pin)
+      shell.xdc.addIOStandard(io, "LVCMOS18")
+      shell.xdc.addIOB(io)
+    } }
+    packagePinsWithPackageIOs drop 1 foreach { case (pin, io) => {
+      shell.xdc.addPullup(io)
+    } }
+*/
+  } }
+}
+class SPIFlashVCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: SPIFlashShellInput)(implicit val valName: ValName)
+  extends SPIFlashShellPlacer[VCU118ShellBasicOverlays] {
+  def place(designInput: SPIFlashDesignInput) = new SPIFlashVCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+*/
+
+object PMODVCU118PinConstraints {
+  val pins = Seq(Seq("AY14","AV16","AY15","AU16","AW15","AT15","AV15","AT16"),
+                 Seq("N28","P29","M30","L31","N30","M31","P30","R29"))
+}
+class PMODVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: PMODDesignInput, val shellInput: PMODShellInput)
+  extends PMODXilinxPlacedOverlay(name, designInput, shellInput, packagePin = PMODVCU118PinConstraints.pins(shellInput.index), ioStandard = "LVCMOS12")
+class PMODVCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: PMODShellInput)(implicit val valName: ValName)
+  extends PMODShellPlacer[VCU118ShellBasicOverlays] {
+  def place(designInput: PMODDesignInput) = new PMODVCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+
+class FMCJTAGVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: JTAGDebugDesignInput, val shellInput: JTAGDebugShellInput)
+  extends JTAGDebugXilinxPlacedOverlay(name, designInput, shellInput)
+{
+  shell { InModuleBody {
+    shell.sdc.addClock("JTCK", IOPin(io.jtag_TCK), 10)
+    shell.sdc.addGroup(clocks = Seq("JTCK"))
+    shell.xdc.clockDedicatedRouteFalse(IOPin(io.jtag_TCK))
+    val packagePinsWithPackageIOs = Seq(("AL12", IOPin(io.jtag_TCK)),
+                                        ("AN15", IOPin(io.jtag_TMS)),
+                                        ("AP15", IOPin(io.jtag_TDI)),
+                                        ("AM12", IOPin(io.jtag_TDO)),
+                                        ("AK12", IOPin(io.srst_n)))
+
+    packagePinsWithPackageIOs foreach { case (pin, io) => {
+      shell.xdc.addPackagePin(io, pin)
+      shell.xdc.addIOStandard(io, "LVCMOS18")
+      shell.xdc.addPullup(io)
+      shell.xdc.addIOB(io)
+    } }
+  } }
+}
+class FMCJTAGVCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: JTAGDebugShellInput)(implicit val valName: ValName)
+  extends JTAGDebugShellPlacer[VCU118ShellBasicOverlays] {
+  def place(designInput: JTAGDebugDesignInput) = new FMCJTAGVCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+
+class PeripheralsVCU118Shell(implicit p: Parameters) extends VCU118Shell{
+  //Shoukd UART be here?
+  val pmod      = Seq.tabulate(2)(i => Overlay(PMODOverlayKey, new PMODVCU118ShellPlacer(this, PMODShellInput(index = i))))
+  val fmcJTAG = Overlay(JTAGDebugOverlayKey, new FMCJTAGVCU118ShellPlacer(this, JTAGDebugShellInput()))
+}
+
+/*
+// Something similar to this will need to be in the tip level Sesame Shell
+class VCU118Shell()(implicit p: Parameters) extends VCU118ShellBasicOverlays
+{
+  // PLL reset causes
+  val pllReset = InModuleBody { Wire(Bool()) }
+
+  // Order matters; ddr depends on sys_clock
+  val topDesign = LazyModule(p(DesignKey)(designParameters))
+
+  // Place the sys_clock at the Shell if the user didn't ask for it
+  designParameters(ClockInputOverlayKey).foreach { unused =>
+    val source = unused.place(ClockInputDesignInput()).overlayOutput.node
+    val sink = ClockSinkNode(Seq(ClockSinkParameters()))
+    sink := source
+  }
+
+  override lazy val module = new LazyRawModuleImp(this) {
+    val reset = IO(Input(Bool()))
+    xdc.addPackagePin(reset, "L19")
+    xdc.addIOStandard(reset, "LVCMOS12")
+
+    val reset_ibuf = Module(new IBUF)
+    reset_ibuf.io.I := reset
+
+    val sysclk: Clock = sys_clock.get() match {
+      case Some(x: SysClockVCU118PlacedOverlay) => x.clock
+    }
+
+    val powerOnReset: Bool = PowerOnResetFPGAOnly(sysclk)
+    sdc.addAsyncPath(Seq(powerOnReset))
+
+    val ereset: Bool = chiplink.get() match {
+      case Some(x: ChipLinkVCU118PlacedOverlay) => !x.ereset_n
+      case _ => false.B
+    }
+
+    pllReset := (reset_ibuf.io.O || powerOnReset || ereset)
+  }
+}
+*/

--- a/src/main/scala/shell/xilinx/PeripheralsVCU118Shell.scala
+++ b/src/main/scala/shell/xilinx/PeripheralsVCU118Shell.scala
@@ -45,30 +45,128 @@ class SPIFlashVCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput:
 }
 */
 
+class UARTPeripheralVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: UARTDesignInput, val shellInput: UARTShellInput)
+  extends UARTXilinxPlacedOverlay(name, designInput, shellInput, true)
+{
+    shell { InModuleBody {
+    val uartLocations = List(List("AY25", "BB22", "AW25", "BB21"), List("AW11", "AP13", "AY10", "AR13")) //uart0 - USB, uart1 - FMC 105 debug card J20 p1-rx p2-tx p3-ctsn p4-rtsn
+    val packagePinsWithPackageIOs = Seq((uartLocations(shellInput.index)(0), IOPin(io.ctsn.get)),
+                                        (uartLocations(shellInput.index)(1), IOPin(io.rtsn.get)),
+                                        (uartLocations(shellInput.index)(2), IOPin(io.rxd)),
+                                        (uartLocations(shellInput.index)(3), IOPin(io.txd)))
+
+    packagePinsWithPackageIOs foreach { case (pin, io) => {
+      shell.xdc.addPackagePin(io, pin)
+      shell.xdc.addIOStandard(io, "LVCMOS18")
+      shell.xdc.addIOB(io)
+    } }
+  } }
+}
+
+class UARTPeripheralVCU118ShellPlacer(val shell: VCU118ShellBasicOverlays, val shellInput: UARTShellInput)(implicit val valName: ValName)
+  extends UARTShellPlacer[VCU118ShellBasicOverlays]
+{
+  def place(designInput: UARTDesignInput) = new UARTPeripheralVCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+
+class I2CPeripheralVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: I2CDesignInput, val shellInput: I2CShellInput)
+  extends I2CXilinxPlacedOverlay(name, designInput, shellInput)
+{
+    shell { InModuleBody {
+    val i2cLocations = List(List("BA14", "AW12"), List("BB14", "AY12")) //i2c0: J1 p37-scl p38-sda i2c1: J2 p39-scl p40-sda
+    val packagePinsWithPackageIOs = Seq((i2cLocations(shellInput.index)(0), IOPin(io.scl)),
+                                        (i2cLocations(shellInput.index)(1), IOPin(io.sda)))
+
+    packagePinsWithPackageIOs foreach { case (pin, io) => {
+      shell.xdc.addPackagePin(io, pin)
+      shell.xdc.addIOStandard(io, "LVCMOS18")
+      shell.xdc.addIOB(io)
+    } }
+  } }
+}
+
+class I2CPeripheralVCU118ShellPlacer(val shell: VCU118ShellBasicOverlays, val shellInput: I2CShellInput)(implicit val valName: ValName)
+  extends I2CShellPlacer[VCU118ShellBasicOverlays]
+{
+  def place(designInput: I2CDesignInput) = new I2CPeripheralVCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+
+class QSPIPeripheralVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: SPIFlashDesignInput, val shellInput: SPIFlashShellInput)
+  extends SPIFlashXilinxPlacedOverlay(name, designInput, shellInput)
+{
+    shell { InModuleBody {
+    val qspiLocations = List(List("AY9", "BB13", "BA9", "BB12", "BF10", "BA16")) //J1 pins 1-6 and 7-12 (sck, cs, dq0-3) 
+//FIX when built in spi flash is integrated
+    val packagePinsWithPackageIOs = Seq((qspiLocations(shellInput.index)(0), IOPin(io.qspi_sck)),
+                                        (qspiLocations(shellInput.index)(1), IOPin(io.qspi_cs)),
+                                        (qspiLocations(shellInput.index)(2), IOPin(io.qspi_dq(0))),
+                                        (qspiLocations(shellInput.index)(3), IOPin(io.qspi_dq(1))),
+                                        (qspiLocations(shellInput.index)(4), IOPin(io.qspi_dq(2))),
+                                        (qspiLocations(shellInput.index)(5), IOPin(io.qspi_dq(3))))
+
+    packagePinsWithPackageIOs foreach { case (pin, io) => {
+      shell.xdc.addPackagePin(io, pin)
+      shell.xdc.addIOStandard(io, "LVCMOS18")
+      shell.xdc.addIOB(io)
+    } }
+    packagePinsWithPackageIOs drop 1 foreach { case (pin, io) => {
+      shell.xdc.addPullup(io)
+    } }
+  } }
+}
+
+class QSPIPeripheralVCU118ShellPlacer(val shell: VCU118ShellBasicOverlays, val shellInput: SPIFlashShellInput)(implicit val valName: ValName)
+  extends SPIFlashShellPlacer[VCU118ShellBasicOverlays]
+{
+  def place(designInput: SPIFlashDesignInput) = new QSPIPeripheralVCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+
+class GPIOPeripheralVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: GPIODesignInput, val shellInput: GPIOShellInput)
+  extends GPIOXilinxPlacedOverlay(name, designInput, shellInput)
+{
+    shell { InModuleBody {
+    val gpioLocations = List("AU11", "AT12", "AV11", "AU12", "AW13", "AK15", "AY13", "AL15", "AN16", "AL14", "AP16", "AM14", "BF9", "BA15", "BC11", "BC14") //J20 pins 5-16, J1 pins 7-10
+    val iosWithLocs = io.gpio.zip(gpioLocations)
+    val packagePinsWithPackageIOs = iosWithLocs.map { case (io, pin) => (pin, IOPin(io)) }
+    println(packagePinsWithPackageIOs)
+
+    packagePinsWithPackageIOs foreach { case (pin, io) => {
+      shell.xdc.addPackagePin(io, pin)
+      shell.xdc.addIOStandard(io, "LVCMOS18")
+      shell.xdc.addIOB(io)
+    } }
+  } }
+}
+
+class GPIOPeripheralVCU118ShellPlacer(val shell: VCU118ShellBasicOverlays, val shellInput: GPIOShellInput)(implicit val valName: ValName)
+  extends GPIOShellPlacer[VCU118ShellBasicOverlays] {
+
+  def place(designInput: GPIODesignInput) = new GPIOPeripheralVCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+
 object PMODVCU118PinConstraints {
   val pins = Seq(Seq("AY14","AV16","AY15","AU16","AW15","AT15","AV15","AT16"),
                  Seq("N28","P29","M30","L31","N30","M31","P30","R29"))
 }
 class PMODVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: PMODDesignInput, val shellInput: PMODShellInput)
-  extends PMODXilinxPlacedOverlay(name, designInput, shellInput, packagePin = PMODVCU118PinConstraints.pins(shellInput.index), ioStandard = "LVCMOS12")
+  extends PMODXilinxPlacedOverlay(name, designInput, shellInput, packagePin = PMODVCU118PinConstraints.pins(shellInput.index), ioStandard = "LVCMOS18")
 class PMODVCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: PMODShellInput)(implicit val valName: ValName)
   extends PMODShellPlacer[VCU118ShellBasicOverlays] {
   def place(designInput: PMODDesignInput) = new PMODVCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
 }
 
-class FMCJTAGVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: JTAGDebugDesignInput, val shellInput: JTAGDebugShellInput)
+class PMODJTAGVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: String, val designInput: JTAGDebugDesignInput, val shellInput: JTAGDebugShellInput)
   extends JTAGDebugXilinxPlacedOverlay(name, designInput, shellInput)
 {
   shell { InModuleBody {
     shell.sdc.addClock("JTCK", IOPin(io.jtag_TCK), 10)
     shell.sdc.addGroup(clocks = Seq("JTCK"))
     shell.xdc.clockDedicatedRouteFalse(IOPin(io.jtag_TCK))
-    val packagePinsWithPackageIOs = Seq(("AL12", IOPin(io.jtag_TCK)),
-                                        ("AN15", IOPin(io.jtag_TMS)),
-                                        ("AP15", IOPin(io.jtag_TDI)),
-                                        ("AM12", IOPin(io.jtag_TDO)),
-                                        ("AK12", IOPin(io.srst_n)))
-
+    val packagePinsWithPackageIOs = Seq(("AW15", IOPin(io.jtag_TCK)),
+                                        ("AU16", IOPin(io.jtag_TMS)),
+                                        ("AV16", IOPin(io.jtag_TDI)),
+                                        ("AY14", IOPin(io.jtag_TDO)),
+                                        ("AY15", IOPin(io.srst_n))) 
     packagePinsWithPackageIOs foreach { case (pin, io) => {
       shell.xdc.addPackagePin(io, pin)
       shell.xdc.addIOStandard(io, "LVCMOS18")
@@ -77,55 +175,39 @@ class FMCJTAGVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: Stri
     } }
   } }
 }
-class FMCJTAGVCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: JTAGDebugShellInput)(implicit val valName: ValName)
+class PMODJTAGVCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: JTAGDebugShellInput)(implicit val valName: ValName)
   extends JTAGDebugShellPlacer[VCU118ShellBasicOverlays] {
-  def place(designInput: JTAGDebugDesignInput) = new FMCJTAGVCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
+  def place(designInput: JTAGDebugDesignInput) = new PMODJTAGVCU118PlacedOverlay(shell, valName.name, designInput, shellInput)
 }
 
-class PeripheralsVCU118Shell(implicit p: Parameters) extends VCU118Shell{
-  //Shoukd UART be here?
-  val pmod      = Seq.tabulate(2)(i => Overlay(PMODOverlayKey, new PMODVCU118ShellPlacer(this, PMODShellInput(index = i))))
-  val fmcJTAG = Overlay(JTAGDebugOverlayKey, new FMCJTAGVCU118ShellPlacer(this, JTAGDebugShellInput()))
-}
+abstract class PeripheralsVCU118Shell(implicit p: Parameters) extends VCU118ShellBasicOverlays{
+  //val pmod_female      = Overlay(PMODOverlayKey, new PMODVCU118ShellPlacer(this, PMODShellInput(index = 0)))
+  val pmodJTAG = Overlay(JTAGDebugOverlayKey, new PMODJTAGVCU118ShellPlacer(this, JTAGDebugShellInput()))
+  val gpio           = Overlay(GPIOOverlayKey,       new GPIOPeripheralVCU118ShellPlacer(this, GPIOShellInput()))
+  val uart  = Seq.tabulate(2) { i => Overlay(UARTOverlayKey, new UARTPeripheralVCU118ShellPlacer(this, UARTShellInput(index = i))(valName = ValName(s"uart$i"))) }
+  val qspi      = Seq.tabulate(0) { i => Overlay(SPIFlashOverlayKey, new QSPIPeripheralVCU118ShellPlacer(this, SPIFlashShellInput(index = i))(valName = ValName(s"qspi$i"))) }
+  val i2c       = Seq.tabulate(2) { i => Overlay(I2COverlayKey, new I2CPeripheralVCU118ShellPlacer(this, I2CShellInput(index = i))(valName = ValName(s"i2c$i"))) }
 
-/*
-// Something similar to this will need to be in the tip level Sesame Shell
-class VCU118Shell()(implicit p: Parameters) extends VCU118ShellBasicOverlays
-{
-  // PLL reset causes
-  val pllReset = InModuleBody { Wire(Bool()) }
-
-  // Order matters; ddr depends on sys_clock
   val topDesign = LazyModule(p(DesignKey)(designParameters))
-
-  // Place the sys_clock at the Shell if the user didn't ask for it
-  designParameters(ClockInputOverlayKey).foreach { unused =>
-    val source = unused.place(ClockInputDesignInput()).overlayOutput.node
-    val sink = ClockSinkNode(Seq(ClockSinkParameters()))
-    sink := source
-  }
+  p(ClockInputOverlayKey).foreach(_.place(ClockInputDesignInput()))
 
   override lazy val module = new LazyRawModuleImp(this) {
     val reset = IO(Input(Bool()))
+    val por_clock = sys_clock.get.get.asInstanceOf[SysClockVCU118PlacedOverlay].clock
+    val powerOnReset = PowerOnResetFPGAOnly(por_clock)
+
     xdc.addPackagePin(reset, "L19")
     xdc.addIOStandard(reset, "LVCMOS12")
 
     val reset_ibuf = Module(new IBUF)
     reset_ibuf.io.I := reset
 
-    val sysclk: Clock = sys_clock.get() match {
-      case Some(x: SysClockVCU118PlacedOverlay) => x.clock
-    }
-
-    val powerOnReset: Bool = PowerOnResetFPGAOnly(sysclk)
     sdc.addAsyncPath(Seq(powerOnReset))
 
     val ereset: Bool = chiplink.get() match {
       case Some(x: ChipLinkVCU118PlacedOverlay) => !x.ereset_n
       case _ => false.B
     }
-
-    pllReset := (reset_ibuf.io.O || powerOnReset || ereset)
+   pllReset := reset_ibuf.io.O || powerOnReset || ereset
   }
 }
-*/

--- a/src/main/scala/shell/xilinx/SPIFlashXilinxOverlay.scala
+++ b/src/main/scala/shell/xilinx/SPIFlashXilinxOverlay.scala
@@ -2,6 +2,7 @@
 package sifive.fpgashells.shell.xilinx
 
 import chisel3._
+import chisel3.util.Cat
 import freechips.rocketchip.diplomacy._
 import sifive.fpgashells.shell._
 import sifive.fpgashells.ip.xilinx._
@@ -11,13 +12,36 @@ abstract class SPIFlashXilinxPlacedOverlay(name: String, di: SPIFlashDesignInput
 {
   def shell: XilinxShell
 
+  //val dqiVec = VecInit.tabulate(4)(j =>tlqspiSink.bundle.dq(j))
   shell { InModuleBody {
-    UIntToAnalog(tlqspiSink.bundle.sck  , io.qspi_sck, true.B)
-    UIntToAnalog(tlqspiSink.bundle.cs(0), io.qspi_cs , true.B)
+    if (!si.vcu118SU) {
+      UIntToAnalog(tlqspiSink.bundle.sck  , io.qspi_sck, true.B)
+      UIntToAnalog(tlqspiSink.bundle.cs(0), io.qspi_cs , true.B)
 
-    tlqspiSink.bundle.dq.zip(io.qspi_dq).foreach { case(design_dq, io_dq) => 
-      UIntToAnalog(design_dq.o, io_dq, design_dq.oe)
-      design_dq.i := AnalogToUInt(io_dq)
+      tlqspiSink.bundle.dq.zip(io.qspi_dq).foreach { case(design_dq, io_dq) => 
+        UIntToAnalog(design_dq.o, io_dq, design_dq.oe)
+        design_dq.i := AnalogToUInt(io_dq)
+      }
+    } else {
+      // If on vcu118, to communicate with Flash, STARTUPE3 primitive needs to be connected and hooked uo tp 
+      // spi, rather than a top level connection
+      val se3 = Module(new STARTUPE3())
+      se3.io.USRDONEO   := true.B
+      se3.io.USRDONETS  := true.B
+      se3.io.USRCCLKO   := tlqspiSink.bundle.sck.asClock
+      se3.io.USRCCLKTS  := false.B
+      se3.io.FCSBO      := tlqspiSink.bundle.cs(0)
+      se3.io.FCSBTS     := false.B
+      se3.io.DO         := Cat(tlqspiSink.bundle.dq.map(_.o))
+      se3.io.DTS        := Cat(tlqspiSink.bundle.dq.map(_.oe))
+      tlqspiSink.bundle.dq(0).i            := se3.io.DI(0)
+      tlqspiSink.bundle.dq(1).i            := se3.io.DI(1)
+      tlqspiSink.bundle.dq(2).i            := se3.io.DI(2)
+      tlqspiSink.bundle.dq(3).i            := se3.io.DI(3)
+      se3.io.GSR        := false.B
+      se3.io.GTS        := false.B
+      se3.io.KEYCLEARB  := false.B
+      se3.io.PACK       := false.B
     }
   } }
 }

--- a/src/main/scala/shell/xilinx/VCU118NewShell.scala
+++ b/src/main/scala/shell/xilinx/VCU118NewShell.scala
@@ -80,7 +80,7 @@ class SPIFlashVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: Str
 {
 
   shell { InModuleBody { 
-    val packagePinsWithPackageIOs = Seq(("AF13", IOPin(io.qspi_sck)),
+    /*val packagePinsWithPackageIOs = Seq(("AF13", IOPin(io.qspi_sck)),
       ("AJ11", IOPin(io.qspi_cs)),
       ("AP11", IOPin(io.qspi_dq(0))),
       ("AN11", IOPin(io.qspi_dq(1))),
@@ -89,11 +89,13 @@ class SPIFlashVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: Str
 
     packagePinsWithPackageIOs foreach { case (pin, io) => {
       shell.xdc.addPackagePin(io, pin)
-    //  shell.xdc.addIOStandard(io, "LVCMOS18")
+      shell.xdc.addIOStandard(io, "LVCMOS18")
+      shell.xdc.addIOB(io)
     } }
-    //packagePinsWithPackageIOs drop 1 foreach { case (pin, io) => {
-    //  shell.xdc.addPullup(io)
-    //} }
+    packagePinsWithPackageIOs drop 1 foreach { case (pin, io) => {
+      shell.xdc.addPullup(io)
+    } }
+*/
   } }
 }
 class SPIFlashVCU118ShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput: SPIFlashShellInput)(implicit val valName: ValName)
@@ -240,12 +242,14 @@ class JTAGDebugVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: St
     val packagePinsWithPackageIOs = Seq(("P29", IOPin(io.jtag_TCK)),
                                         ("L31", IOPin(io.jtag_TMS)),
                                         ("M31", IOPin(io.jtag_TDI)),
-                                        ("R29", IOPin(io.jtag_TDO)))
+                                        ("R29", IOPin(io.jtag_TDO)),
+                                        ("N28", IOPin(io.srst_n)))
 
     packagePinsWithPackageIOs foreach { case (pin, io) => {
       shell.xdc.addPackagePin(io, pin)
       shell.xdc.addIOStandard(io, "LVCMOS18")
       shell.xdc.addPullup(io)
+      shell.xdc.addIOB(io)
     } }
   } }
 }

--- a/src/main/scala/shell/xilinx/VCU118NewShell.scala
+++ b/src/main/scala/shell/xilinx/VCU118NewShell.scala
@@ -399,6 +399,9 @@ class PCIeVCU118EdgeShellPlacer(shell: VCU118ShellBasicOverlays, val shellInput:
 }
 
 abstract class VCU118ShellBasicOverlays()(implicit p: Parameters) extends UltraScaleShell{
+  // PLL reset causes
+  val pllReset = InModuleBody { Wire(Bool()) }
+
   val sys_clock = Overlay(ClockInputOverlayKey, new SysClockVCU118ShellPlacer(this, ClockInputShellInput()))
   val ref_clock = Overlay(ClockInputOverlayKey, new RefClockVCU118ShellPlacer(this, ClockInputShellInput()))
   val led       = Seq.tabulate(8)(i => Overlay(LEDOverlayKey, new LEDVCU118ShellPlacer(this, LEDShellInput(color = "red", number = i))(valName = ValName(s"led_$i"))))
@@ -413,9 +416,6 @@ abstract class VCU118ShellBasicOverlays()(implicit p: Parameters) extends UltraS
 
 class VCU118Shell()(implicit p: Parameters) extends VCU118ShellBasicOverlays
 {
-  // PLL reset causes
-  val pllReset = InModuleBody { Wire(Bool()) }
-
   // Order matters; ddr depends on sys_clock
   val uart      = Overlay(UARTOverlayKey, new UARTVCU118ShellPlacer(this, UARTShellInput()))
   val sdio      = Overlay(SDIOOverlayKey, new SDIOVCU118ShellPlacer(this, SDIOShellInput()))

--- a/src/main/scala/shell/xilinx/VCU118NewShell.scala
+++ b/src/main/scala/shell/xilinx/VCU118NewShell.scala
@@ -404,9 +404,6 @@ abstract class VCU118ShellBasicOverlays()(implicit p: Parameters) extends UltraS
   val led       = Seq.tabulate(8)(i => Overlay(LEDOverlayKey, new LEDVCU118ShellPlacer(this, LEDShellInput(color = "red", number = i))(valName = ValName(s"led_$i"))))
   val switch    = Seq.tabulate(4)(i => Overlay(SwitchOverlayKey, new SwitchVCU118ShellPlacer(this, SwitchShellInput(number = i))(valName = ValName(s"switch_$i"))))
   val ddr       = Overlay(DDROverlayKey, new DDRVCU118ShellPlacer(this, DDRShellInput()))
-  val uart      = Overlay(UARTOverlayKey, new UARTVCU118ShellPlacer(this, UARTShellInput()))
-  val sdio      = Overlay(SDIOOverlayKey, new SDIOVCU118ShellPlacer(this, SDIOShellInput()))
-  val jtag      = Overlay(JTAGDebugOverlayKey, new JTAGDebugVCU118ShellPlacer(this, JTAGDebugShellInput()))
   val qsfp1     = Overlay(EthernetOverlayKey, new QSFP1VCU118ShellPlacer(this, EthernetShellInput()))
   val qsfp2     = Overlay(EthernetOverlayKey, new QSFP2VCU118ShellPlacer(this, EthernetShellInput()))
   val chiplink  = Overlay(ChipLinkOverlayKey, new ChipLinkVCU118ShellPlacer(this, ChipLinkShellInput()))
@@ -420,6 +417,9 @@ class VCU118Shell()(implicit p: Parameters) extends VCU118ShellBasicOverlays
   val pllReset = InModuleBody { Wire(Bool()) }
 
   // Order matters; ddr depends on sys_clock
+  val uart      = Overlay(UARTOverlayKey, new UARTVCU118ShellPlacer(this, UARTShellInput()))
+  val sdio      = Overlay(SDIOOverlayKey, new SDIOVCU118ShellPlacer(this, SDIOShellInput()))
+  val jtag      = Overlay(JTAGDebugOverlayKey, new JTAGDebugVCU118ShellPlacer(this, JTAGDebugShellInput()))
   val fmc       = Overlay(PCIeOverlayKey, new PCIeVCU118FMCShellPlacer(this, PCIeShellInput()))
   val edge      = Overlay(PCIeOverlayKey, new PCIeVCU118EdgeShellPlacer(this, PCIeShellInput()))
 


### PR DESCRIPTION
VCU118 shell refactored:

VCU118ShellBasicOverlays - abstract class containing unobjectable overlays for all shells
VCU118Shell - default shell (same name for backwards compatibility)
PeripheralShell - shell with a bunch of peripherals mapped to fmc pins

includes WIP STARTUPE3 stuff, which I wasn't able to get working but think I am reasonably close.