### PR TITLE
Chisel compile warning: deprecated IntSyncCrossingSink

### DIFF
--- a/src/main/scala/devices/microsemi/polarfire_pcie/PolarFireEvalKitPCIeX4.scala
+++ b/src/main/scala/devices/microsemi/polarfire_pcie/PolarFireEvalKitPCIeX4.scala
@@ -59,7 +59,7 @@ class PolarFireEvalKitPCIeX4(implicit p: Parameters) extends LazyModule with Has
       := axi_to_pcie.master)
 
   val TLScope = LazyModule(new SimpleLazyModule with LazyScope)
-  val intnode: IntOutwardNode = IntSyncCrossingSink() := TLScope {
+  val intnode: IntOutwardNode = IntSyncAsyncCrossingSink() := TLScope {
     IntSyncCrossingSource(alreadyRegistered = true) := axi_to_pcie.intnode
   }
 


### PR DESCRIPTION
### Why is this change being made?

fix this Chisel compile warning:
```
[warn] /federation/fpga-shells/src/main/scala/devices/microsemi/polarfire_pcie/PolarFireEvalKitPCIeX4.scala:62:33: method apply in object IntSyncCrossingSink is deprecated (since rocket-chip 1.2): IntSyncCrossingSink which used the `sync` parameter to determine crossing type is deprecated. Use IntSyncAsyncCrossingSink, IntSyncRationalCrossingSink, or IntSyncSyncCrossingSink instead for > 1, 1, and 0 sync values respectively
[warn]   val intnode: IntOutwardNode = IntSyncCrossingSink() := TLScope {
[warn]                                 ^
```

### Type of change
- Paying Off Technical Debt