### PR TITLE
Locate IO srst_n to proper pin on LCD connector

### DIFF
--- a/src/main/scala/shell/xilinx/VC707NewShell.scala
+++ b/src/main/scala/shell/xilinx/VC707NewShell.scala
@@ -159,6 +159,7 @@ class JTAGDebugVC707PlacedOverlay(val shell: VC707Shell, name: String, val desig
     val packagePinsWithPackageIOs = Seq(("AT42", IOPin(io.jtag_TCK)),
                                         ("AR38", IOPin(io.jtag_TMS)),
                                         ("AR39", IOPin(io.jtag_TDI)),
+                                        ("AR42", IOPin(io.srst_n)),
                                         ("AT40", IOPin(io.jtag_TDO)))
     packagePinsWithPackageIOs foreach { case (pin, io) => {
       shell.xdc.addPackagePin(io, pin)


### PR DESCRIPTION
This PR applies a location constraint and pullup to the srst_n input in VC707 builds.  I know VC707 is not officially supported any more, but some engineers still have them and it's useful to be able to do internal builds targeted at VC707.  Before this change, Vivado would error out because this I/O is in the design but it doesn't have a location constraint.

With this change, I was able to successfully build standard core U77 for VC707 using PCS.