### PR TITLE
Add padPlace: LazyScope value

### DIFF
--- a/src/main/scala/shell/GPIOOverlay.scala
+++ b/src/main/scala/shell/GPIOOverlay.scala
@@ -30,6 +30,6 @@ abstract class GPIOPlacedOverlay(
 
   def ioFactory = new ShellGPIOPortIO(di.gpioParams.width)
 
-  val tlgpioSink = shell { di.node.makeSink }
+  val tlgpioSink = padPlace { di.node.makeSink }
   def overlayOutput = GPIOOverlayOutput()
 }

--- a/src/main/scala/shell/GPIOOverlay.scala
+++ b/src/main/scala/shell/GPIOOverlay.scala
@@ -30,6 +30,6 @@ abstract class GPIOPlacedOverlay(
 
   def ioFactory = new ShellGPIOPortIO(di.gpioParams.width)
 
-  val tlgpioSink = padPlace { di.node.makeSink }
+  val tlgpioSink = sinkScope { di.node.makeSink }
   def overlayOutput = GPIOOverlayOutput()
 }

--- a/src/main/scala/shell/I2COverlay.scala
+++ b/src/main/scala/shell/I2COverlay.scala
@@ -33,7 +33,7 @@ abstract class I2CPlacedOverlay(
 
   def ioFactory = new ShellI2CPortIO
 
-  val tli2cSink = shell { di.node.makeSink }
+  val tli2cSink = padPlace { di.node.makeSink }
 
   def overlayOutput = I2COverlayOutput()
 }

--- a/src/main/scala/shell/I2COverlay.scala
+++ b/src/main/scala/shell/I2COverlay.scala
@@ -33,7 +33,7 @@ abstract class I2CPlacedOverlay(
 
   def ioFactory = new ShellI2CPortIO
 
-  val tli2cSink = padPlace { di.node.makeSink }
+  val tli2cSink = sinkScope { di.node.makeSink }
 
   def overlayOutput = I2COverlayOutput()
 }

--- a/src/main/scala/shell/IOShell.scala
+++ b/src/main/scala/shell/IOShell.scala
@@ -144,6 +144,7 @@ trait IOPlacedOverlay[IO <: Data, DesignInput, ShellInput, OverlayOutput] extend
 {
   def ioFactory: IO
   def shell: IOShell
+  def padPlace: LazyScope = shell
 
   val io = shell { InModuleBody {
     val port = IO(ioFactory)

--- a/src/main/scala/shell/IOShell.scala
+++ b/src/main/scala/shell/IOShell.scala
@@ -144,7 +144,7 @@ trait IOPlacedOverlay[IO <: Data, DesignInput, ShellInput, OverlayOutput] extend
 {
   def ioFactory: IO
   def shell: IOShell
-  def padPlace: LazyScope = shell
+  def sinkScope: LazyScope = shell
 
   val io = shell { InModuleBody {
     val port = IO(ioFactory)

--- a/src/main/scala/shell/JTAGDebugOverlay.scala
+++ b/src/main/scala/shell/JTAGDebugOverlay.scala
@@ -44,7 +44,7 @@ abstract class JTAGDebugPlacedOverlay(
   def ioFactory = new ShellJTAGIO
 
   val jtagDebugSource = BundleBridgeSource(() => new FlippedJTAGIO())
-  val jtagDebugSink = padPlace { jtagDebugSource.makeSink }
+  val jtagDebugSink = sinkScope { jtagDebugSource.makeSink }
   val jtout = InModuleBody { jtagDebugSource.bundle}
   def overlayOutput = JTAGDebugOverlayOutput(jtag = jtout)
 }

--- a/src/main/scala/shell/JTAGDebugOverlay.scala
+++ b/src/main/scala/shell/JTAGDebugOverlay.scala
@@ -44,7 +44,7 @@ abstract class JTAGDebugPlacedOverlay(
   def ioFactory = new ShellJTAGIO
 
   val jtagDebugSource = BundleBridgeSource(() => new FlippedJTAGIO())
-  val jtagDebugSink = shell { jtagDebugSource.makeSink }
+  val jtagDebugSink = padPlace { jtagDebugSource.makeSink }
   val jtout = InModuleBody { jtagDebugSource.bundle}
   def overlayOutput = JTAGDebugOverlayOutput(jtag = jtout)
 }

--- a/src/main/scala/shell/PWMOverlay.scala
+++ b/src/main/scala/shell/PWMOverlay.scala
@@ -31,7 +31,7 @@ abstract class PWMPlacedOverlay(
 
   def ioFactory = new ShellPWMPortIO
 
-  val tlpwmSink = padPlace { di.node.makeSink }
+  val tlpwmSink = sinkScope { di.node.makeSink }
 
   def overlayOutput = PWMOverlayOutput()
 }

--- a/src/main/scala/shell/PWMOverlay.scala
+++ b/src/main/scala/shell/PWMOverlay.scala
@@ -31,7 +31,7 @@ abstract class PWMPlacedOverlay(
 
   def ioFactory = new ShellPWMPortIO
 
-  val tlpwmSink = shell { di.node.makeSink }
+  val tlpwmSink = padPlace { di.node.makeSink }
 
   def overlayOutput = PWMOverlayOutput()
 }

--- a/src/main/scala/shell/SPIFlashOverlay.scala
+++ b/src/main/scala/shell/SPIFlashOverlay.scala
@@ -34,7 +34,7 @@ abstract class SPIFlashPlacedOverlay(
 
   def ioFactory = new ShellSPIFlashPortIO
 
-  val tlqspiSink = padPlace { di.node.makeSink }
+  val tlqspiSink = sinkScope { di.node.makeSink }
 
   def overlayOutput = SPIFlashOverlayOutput()
 }

--- a/src/main/scala/shell/SPIFlashOverlay.scala
+++ b/src/main/scala/shell/SPIFlashOverlay.scala
@@ -34,7 +34,7 @@ abstract class SPIFlashPlacedOverlay(
 
   def ioFactory = new ShellSPIFlashPortIO
 
-  val tlqspiSink = shell { di.node.makeSink }
+  val tlqspiSink = padPlace { di.node.makeSink }
 
   def overlayOutput = SPIFlashOverlayOutput()
 }

--- a/src/main/scala/shell/UARTOverlay.scala
+++ b/src/main/scala/shell/UARTOverlay.scala
@@ -36,7 +36,7 @@ abstract class UARTPlacedOverlay(
 
   def ioFactory = new ShellUARTPortIO(flowControl)
 
-  val tluartSink = shell { di.node.makeSink }
+  val tluartSink = padPlace { di.node.makeSink }
 
   def overlayOutput = UARTOverlayOutput()
 }

--- a/src/main/scala/shell/UARTOverlay.scala
+++ b/src/main/scala/shell/UARTOverlay.scala
@@ -36,7 +36,7 @@ abstract class UARTPlacedOverlay(
 
   def ioFactory = new ShellUARTPortIO(flowControl)
 
-  val tluartSink = padPlace { di.node.makeSink }
+  val tluartSink = sinkScope { di.node.makeSink }
 
   def overlayOutput = UARTOverlayOutput()
 }


### PR DESCRIPTION
background: At the request of the physical implementation & design team,
 	    we needed a space to put the pad in one place.
	    So I created a value called padPlace.
            padPlace default value is shell.

Add def padPlace: LazyScope = shell in IOPlacedOverlay trait

Changed the existing sink scope from shell to padPlace.
  in GPIOPlacedOverlay, I2CPlacedOverlay, JTAGDebugPlacedOverlay,
     PWMPlacedOverlay, SPIFlashPlacedOverlay, UARTPlacedOverlay