### PR TITLE
xdma: support BARs with physical address != PCIe address

### DIFF
--- a/src/main/scala/shell/PCIeOverlay.scala
+++ b/src/main/scala/shell/PCIeOverlay.scala
@@ -13,6 +13,7 @@ case class PCIeDesignInput(
   wrangler: ClockAdapterNode,
   bars: Seq[AddressSet] = Seq(AddressSet(0x40000000L, 0x1FFFFFFFL)),
   ecam: BigInt = 0x2000000000L,
+  bases: Seq[BigInt] = Nil, // remap bars to these PCIe base addresses
   corePLL: PLLNode)(
   implicit val p: Parameters)
 

--- a/src/main/scala/shell/xilinx/VCU118NewShell.scala
+++ b/src/main/scala/shell/xilinx/VCU118NewShell.scala
@@ -354,6 +354,7 @@ class PCIeVCU118FMCPlacedOverlay(val shell: VCU118ShellBasicOverlays, name: Stri
     location = "X0Y3",
     bars     = designInput.bars,
     control  = designInput.ecam,
+    bases    = designInput.bases,
     lanes    = 4))
 {
   shell { InModuleBody {
@@ -394,6 +395,7 @@ class PCIeVCU118EdgePlacedOverlay(val shell: VCU118ShellBasicOverlays, name: Str
     location = "X1Y2",
     bars     = designInput.bars,
     control  = designInput.ecam,
+    bases    = designInput.bases,
     lanes    = 8))
 {
   shell { InModuleBody {


### PR DESCRIPTION
This is necessary to support PCIe controllers without access to physical
addresses below 4GiB. The kernel appears to happily map even 32-bit device
BARs to high 64-bit base-addresses for the RC BARs.