### PR TITLE
refactor tcl code that wasn't executing correctly

### DIFF
--- a/xilinx/common/tcl/prologue.tcl
+++ b/xilinx/common/tcl/prologue.tcl
@@ -100,7 +100,9 @@ proc load_vsrc_manifest {obj vsrc_manifest} {
     }
   }
   # Read environment variable vsrcs and append to relative_files
-  if {[info exists env_var_srcs)]} {
+  upvar #0 env_var_srcs env_var_srcs
+  set additions [info exists env_var_srcs]
+  if {$additions} {
     if {[info exists ::env($env_var_srcs)]} {
       set resources [split $::env($env_var_srcs) :]
       set relative_files [list {*}$relative_files {*}$resources]


### PR DESCRIPTION
For some reason, the previous code was always returning 0 (even after adding the upvar). When refactored this way, it works again