### PR TITLE
DDR controllers: do not use deprecated stripBits parameter of TLToAXI4

### DIFF
--- a/src/main/scala/devices/microsemi/polarfire_ddr3/MicrosemiPolarFireDDR3.scala
+++ b/src/main/scala/devices/microsemi/polarfire_ddr3/MicrosemiPolarFireDDR3.scala
@@ -142,7 +142,7 @@ class PolarFireEvalKitDDR3(c : PolarFireEvalKitDDR3Params)(implicit p: Parameter
   val depth = ranges.head.size
 
   val buffer  = LazyModule(new TLBuffer)
-  val toaxi4  = LazyModule(new TLToAXI4(adapterName = Some("mem"), stripBits = 1))
+  val toaxi4  = LazyModule(new TLToAXI4(adapterName = Some("mem")))
   val indexer = LazyModule(new AXI4IdIndexer(idBits = 4))
   val deint   = LazyModule(new AXI4Deinterleaver(p(CacheBlockBytes)))
   val yank    = LazyModule(new AXI4UserYanker)

--- a/src/main/scala/devices/microsemi/polarfire_ddr4/MicrosemiPolarFireDDR4.scala
+++ b/src/main/scala/devices/microsemi/polarfire_ddr4/MicrosemiPolarFireDDR4.scala
@@ -143,7 +143,7 @@ class PolarFireEvalKitDDR4(c : PolarFireEvalKitDDR4Params)(implicit p: Parameter
   val depth = ranges.head.size
 
   val buffer  = LazyModule(new TLBuffer)
-  val toaxi4  = LazyModule(new TLToAXI4(adapterName = Some("mem"), stripBits = 1))
+  val toaxi4  = LazyModule(new TLToAXI4(adapterName = Some("mem")))
   val indexer = LazyModule(new AXI4IdIndexer(idBits = 4))
   val deint   = LazyModule(new AXI4Deinterleaver(p(CacheBlockBytes)))
   val yank    = LazyModule(new AXI4UserYanker)

--- a/src/main/scala/devices/xilinx/xilinxvc707mig/XilinxVC707MIG.scala
+++ b/src/main/scala/devices/xilinx/xilinxvc707mig/XilinxVC707MIG.scala
@@ -151,7 +151,7 @@ class XilinxVC707MIG(c : XilinxVC707MIGParams, crossing: ClockCrossingType = Asy
   val depth = ranges.head.size
 
   val buffer  = LazyModule(new TLBuffer)
-  val toaxi4  = LazyModule(new TLToAXI4(adapterName = Some("mem"), stripBits = 1))
+  val toaxi4  = LazyModule(new TLToAXI4(adapterName = Some("mem")))
   val indexer = LazyModule(new AXI4IdIndexer(idBits = 4))
   val deint   = LazyModule(new AXI4Deinterleaver(p(CacheBlockBytes)))
   val yank    = LazyModule(new AXI4UserYanker)

--- a/src/main/scala/devices/xilinx/xilinxvcu118mig/XilinxVCU118MIG.scala
+++ b/src/main/scala/devices/xilinx/xilinxvcu118mig/XilinxVCU118MIG.scala
@@ -140,7 +140,7 @@ class XilinxVCU118MIG(c : XilinxVCU118MIGParams)(implicit p: Parameters) extends
   val depth = ranges.head.size
 
   val buffer  = LazyModule(new TLBuffer)
-  val toaxi4  = LazyModule(new TLToAXI4(adapterName = Some("mem"), stripBits = 1))
+  val toaxi4  = LazyModule(new TLToAXI4(adapterName = Some("mem")))
   val indexer = LazyModule(new AXI4IdIndexer(idBits = 4))
   val deint   = LazyModule(new AXI4Deinterleaver(p(CacheBlockBytes)))
   val yank    = LazyModule(new AXI4UserYanker)


### PR DESCRIPTION
This parameter was deemed to be inevitably harmful to performance in certain situations and has been deprecated.