### PR TITLE
fix critical warning for Vivado

### DIFF
--- a/src/main/scala/shell/xilinx/VCU118NewShell.scala
+++ b/src/main/scala/shell/xilinx/VCU118NewShell.scala
@@ -263,7 +263,6 @@ class JTAGDebugVCU118PlacedOverlay(val shell: VCU118ShellBasicOverlays, name: St
       shell.xdc.addPackagePin(io, pin_location)
       shell.xdc.addIOStandard(io, pin_voltage)
       shell.xdc.addPullup(io)
-      shell.xdc.addIOB(io)
     }
   } }
 }

--- a/src/main/scala/shell/xilinx/XilinxShell.scala
+++ b/src/main/scala/shell/xilinx/XilinxShell.scala
@@ -29,9 +29,9 @@ class XDC(val name: String)
   }
   def addIOB(io: IOPin) {
     if (io.isOutput) {
-      addConstraint(s"set_property IOB {TRUE} [ get_cells -of_objects [ all_fanin -flat -startpoints_only ${io.sdcPin}]]")
+      addConstraint(s"set_property IOB {TRUE} ${io.sdcPin}")
     } else {
-      addConstraint(s"set_property IOB {TRUE} [ get_cells -of_objects [ all_fanout -flat -endpoints_only ${io.sdcPin}]]")
+      addConstraint(s"set_property IOB {TRUE} ${io.sdcPin}")
     }
   }
   def addSlew(io: IOPin, speed: String) {


### PR DESCRIPTION
This is mentioned in:
https://www.xilinx.com/support/documentation/sw_manuals/xilinx2018_1/ug912-vivado-properties.pdf#page=230