### PR TITLE
remove objectmodule

### DIFF
--- a/src/main/scala/shell/GPIOOverlay.scala
+++ b/src/main/scala/shell/GPIOOverlay.scala
@@ -8,7 +8,7 @@ import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink.TLBusWrapper
 import freechips.rocketchip.interrupts.IntInwardNode
-import freechips.rocketchip.diplomaticobjectmodel.logicaltree.LogicalTreeNode
+
 
 import sifive.blocks.devices.gpio._
 

--- a/src/main/scala/shell/I2COverlay.scala
+++ b/src/main/scala/shell/I2COverlay.scala
@@ -9,7 +9,7 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.subsystem.{BaseSubsystem, PeripheryBus, PeripheryBusKey}
 import freechips.rocketchip.tilelink.TLBusWrapper
 import freechips.rocketchip.interrupts.IntInwardNode
-import freechips.rocketchip.diplomaticobjectmodel.logicaltree.LogicalTreeNode
+
 
 import sifive.blocks.devices.i2c._
 

--- a/src/main/scala/shell/PWMOverlay.scala
+++ b/src/main/scala/shell/PWMOverlay.scala
@@ -9,7 +9,7 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.subsystem.{BaseSubsystem, PeripheryBus, PeripheryBusKey}
 import freechips.rocketchip.tilelink.TLBusWrapper
 import freechips.rocketchip.interrupts.IntInwardNode
-import freechips.rocketchip.diplomaticobjectmodel.logicaltree.LogicalTreeNode
+
 
 import sifive.blocks.devices.pwm._
 

--- a/src/main/scala/shell/PorGenOverlay.scala
+++ b/src/main/scala/shell/PorGenOverlay.scala
@@ -9,7 +9,7 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.subsystem.{BaseSubsystem, PeripheryBus, PeripheryBusKey}
 import freechips.rocketchip.tilelink.TLBusWrapper
 import freechips.rocketchip.interrupts.IntInwardNode
-import freechips.rocketchip.diplomaticobjectmodel.logicaltree.LogicalTreeNode
+
 
 import sifive.blocks.devices.porgen._
 

--- a/src/main/scala/shell/SPIFlashOverlay.scala
+++ b/src/main/scala/shell/SPIFlashOverlay.scala
@@ -8,7 +8,7 @@ import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink.TLBusWrapper
 import freechips.rocketchip.interrupts.IntInwardNode
-import freechips.rocketchip.diplomaticobjectmodel.logicaltree.LogicalTreeNode
+
 
 import sifive.blocks.devices.spi._
 

--- a/src/main/scala/shell/UARTOverlay.scala
+++ b/src/main/scala/shell/UARTOverlay.scala
@@ -9,7 +9,7 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.subsystem.{BaseSubsystem, PeripheryBus, PeripheryBusKey}
 import freechips.rocketchip.tilelink.TLBusWrapper
 import freechips.rocketchip.interrupts.IntInwardNode
-import freechips.rocketchip.diplomaticobjectmodel.logicaltree.LogicalTreeNode
+
 
 import sifive.blocks.devices.uart._
 


### PR DESCRIPTION
This is needed for RC bumping after chipsalliance/rocket-chip#2967 get merged. 